### PR TITLE
chore(vac/sc): update community contracts token import milestone

### DIFF
--- a/content/vac/sc/g/status/community-contracts-token-import.md
+++ b/content/vac/sc/g/status/community-contracts-token-import.md
@@ -26,31 +26,34 @@ gantt
     Production Readiness:
 ```
 
-- status: 5%
+- status: 0%
 - CC: Andrea
+
+**This milestone is updated on weekly basis. For a more up-to-date status head over to the [milestone on GitHub](https://github.com/status-im/communities-contracts/milestone/1).
 
 ### Description
 
-*Note*: This milestones needs further details, which will be agreed apon with Status in an upcoming meeting.
+This milestone is part of the effort to create "Community Vaults".
+Community Vaults allow Status users to create communities that maintain their own token balances and later on allow for airdropping their tokens to other Status users or retail them.
 
-Preliminary description:
+This milestone focusses on the "token import".
+The naming is a bit misleading, but the basic idea is that users:
 
-Design and implement a contract that offers a  token import functionality to communities.
-It should allow:
-- deploying a token vault for a given token
-- depositing tokens to specific token vaults
-- specific community members (token masters) can alter (e.g. airdrop) tokens in the store
-- tokens in the vault can be air dropped
-
-A token vault is basically a community wallet that a community's token masters can airdrop from.
+- create Status communities and deploy a "vault" contract
+- the vault contract acts as a wallet for the community
+- any user can send ERC20 and ERC721 tokens to the vault
 
 ### Justification
 
 
 ### Deliverables
 
-* design description
-* smart contract
+- `CommunityVault` smart contract implementation
+- Migration/upgrade strategy for vaults
+- Ability for users to deposit/import tokens to vault
+- Tests
+- Documentation
+- Formal verification
 
 
 


### PR DESCRIPTION

This updates the milestone `community-contracts-token-import` to reflect
its latest state, taking into account that the deliverables of the
original version of this milestone will be broken down in additional
milestones that will follow in other commits.

Notice that the `status` of the milestone has been set to `0%`. This
isn't exactly representative, as some work has already been done but
hasn't been quantified. This will correct itself as current tasks for
this milestone will be addressed.