### PR TITLE
chore(vac/sc): mark `community-curation-dapp-contracts` as done

### DIFF
--- a/content/vac/sc/g/status/community-contracts-curation-dapp-contracts.md
+++ b/content/vac/sc/g/status/community-contracts-curation-dapp-contracts.md
@@ -26,7 +26,7 @@ gantt
     Production Readiness: 2023-09-15, 2023-10-21
 ```
 
-- status: 95%
+- status: 100%
 - CC: Ricardo
 
 ### Description

--- a/content/vac/sc/index.md
+++ b/content/vac/sc/index.md
@@ -16,7 +16,7 @@ lastmod: 2023-09-21
 * [x] [[ vac/sc/g/status/community-contracts-deployer | community-contracts-deployer ]]
 * [[ vac/sc/g/status/community-contracts-token-import | community-contracts-token-import ]]
 * [[ vac/sc/g/status/community-contracts-maintenance | community-contracts-maintenance ]]
-* [[ vac/sc/g/status/community-contracts-curation-dapp-contracts | community-contracts-curation-dapp-contracts ]]
+* [x] [[ vac/sc/g/status/community-contracts-curation-dapp-contracts | community-contracts-curation-dapp-contracts ]]
 * [x] [[ vac/sc/g/status/snt-optimism-bridge | SNT-optimism-bridge ]]
 * [x] [[ vac/sc/g/status/mimime-token-enhancement | mimime-token-enhancement ]]
 * [[ vac/sc/g/status/mimime-token-maintenance | mimime-token-maintenance ]]


### PR DESCRIPTION
The work for this milestone has been delivered a couple of months ago, so this can be marked as done now.