### PR TITLE
chore: rename multitoken milestone

### DIFF
--- a/content/vac/sc/g/status/community-contracts-batch-tx-ext.md
+++ b/content/vac/sc/g/status/community-contracts-batch-tx-ext.md
@@ -1,7 +1,7 @@
 ---
-title: "Community Contracts Multitoken (EIP1155)"
+title: "Community Contracts CollectibleV1 Batch transaction Extension"
 ---
-## `vac:sc::status:community-contracts-multitoken`
+## `vac:sc::status:community-contracts-batch-tx-ext`
 ---
 
 ```mermaid
@@ -22,7 +22,7 @@ gantt
   tickInterval 1month
   dateFormat YYYY-MM-DD 
   section Status
-    Community Contracts Multitoken: 2024-02-19, 2024-03-21
+    Community Contracts CollectibleV1 Batch transaction Extension: 2024-02-19, 2024-03-21
 ```
 
 - status: 0%
@@ -39,15 +39,17 @@ At the time of creating this milestone, two types of token contracts existed:
 
 These are essentially ERC20 and ERC721 respectively, with some additional functionality, required by Status.
 
-In this milestone, we're adding a new contract that's meant to replace the `CollectibleV1`.
-It's supposed to be an EIP1155 multitoken implementation that otherwise comes with the same custom functionality that the `CollectibleV1` has.
+In this milestone, we're adding support for batch transacting tokens of the `BaseToken` which `CollectibleV1` is derived from. 
 
 ### Justification
 
+Status Desktop needs to allow community owners to first deploy and mint a certain amount of their own token and then batch transact them to other accounts later on.
+
+Right now the only way to do this is to either use the contract's `mintTo()` function, which mints to a list of accounts right away, or to perform multiple transactions for every token to be sent.
 
 ### Deliverables
 
-- `CommunityERC1155` implementation
+- `BaseToken/CollectibleV1` batch transfer functions
 - Tests
 - Documentation
 - Application properties

--- a/content/vac/sc/index.md
+++ b/content/vac/sc/index.md
@@ -18,7 +18,7 @@ lastmod: 2023-09-21
 * [[ vac/sc/g/status/community-contracts-maintenance | community-contracts-maintenance ]]
 * [x] [[ vac/sc/g/status/community-contracts-curation-dapp-contracts | community-contracts-curation-dapp-contracts ]]
 * [[ vac/sc/g/status/community-contracts-vault-token-airdrop | community-contracts-vault-token-airdrop ]]
-* [[ vac/sc/g/status/community-contracts-multitoken | community-contracts-multitoken ]]
+* [[ vac/sc/g/status/community-contracts-batch-tx-ext | community-contracts-batch-tx-ext ]]
 * [x] [[ vac/sc/g/status/snt-optimism-bridge | SNT-optimism-bridge ]]
 * [x] [[ vac/sc/g/status/mimime-token-enhancement | mimime-token-enhancement ]]
 * [[ vac/sc/g/status/mimime-token-maintenance | mimime-token-maintenance ]]


### PR DESCRIPTION
This is done because after research, it turned out we could get away with a different solution. So we're renaming this milestone to something more appropriate.