### PR TITLE
Qa milestones: go-waku, rln, sharding and lib-p2p

### DIFF
--- a/content/vac/qa/g/vac/test-automation-nim-libp2p.md
+++ b/content/vac/qa/g/vac/test-automation-nim-libp2p.md
@@ -22,7 +22,7 @@ gantt
   tickInterval 1month
   dateFormat YYYY-MM-DD 
   section Status
-    Test Automation nim-libp2p:  2024-04-01, 2024-12-31
+    Test Automation nim-libp2p:  2024-01-01, 2024-12-31
 ```
 
 - status: 0%

--- a/content/vac/qa/g/vac/test-automation-nim-libp2p.md
+++ b/content/vac/qa/g/vac/test-automation-nim-libp2p.md
@@ -1,0 +1,38 @@
+---
+title: "Test Automation nim-libp2p"
+---
+## `vac:qa::vac:test-automation-nim-libp2p`
+---
+
+```mermaid
+%%{ 
+  init: { 
+    'theme': 'base', 
+    'themeVariables': { 
+      'primaryColor': '#BB2528', 
+      'primaryTextColor': '#fff', 
+      'primaryBorderColor': '#7C0000', 
+      'lineColor': '#F8B229', 
+      'secondaryColor': '#006100', 
+      'tertiaryColor': '#fff' 
+    } 
+  } 
+}%%
+gantt
+  tickInterval 1month
+  dateFormat YYYY-MM-DD 
+  section Status
+    Test Automation nim-libp2p:  2024-04-01, 2024-12-31
+```
+
+- status: 0%
+- CC: Alex, Roman, Florin
+
+### Description
+
+Add tests and increase coverage for all the [modules](https://github.com/vacp2p/nim-libp2p?tab=readme-ov-file#modules) implemented in nim libp2p
+
+### Justification
+
+
+### Deliverables

--- a/content/vac/qa/g/waku/test-automation-go-waku.md
+++ b/content/vac/qa/g/waku/test-automation-go-waku.md
@@ -25,7 +25,7 @@ gantt
     Test Automation go-waku:  2023-10-01, 2024-02-29
 ```
 
-- status: 70%
+- status: 100%
 - CC: Roman
 
 ### Description
@@ -44,5 +44,38 @@ gantt
 
 ### Deliverables
 
+- filter:
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/filter/filter_ping_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/filter/filter_proto_ident_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/filter/filter_push_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/filter/filter_subscribe_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/filter/filter_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/filter/filter_unsubscribe_test.go
 
+
+- lightpush:
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/lightpush/waku_lightpush_test.go
+
+- store:
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/store/waku_store_client.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/store/waku_store_protocol_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/store/waku_store_query_test.go
+
+- relay:
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/relay/waku_relay_test.go
+
+- peer exchange:
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/protocol/peer_exchange/waku_peer_exchange_test.go
+
+- peer & connection management:
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/peermanager/connection_gater_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/peermanager/service_slot_test.go
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/peermanager/topic_event_handler_test.go
+
+- discv5
+  - https://github.com/waku-org/go-waku/blob/master/waku/v2/discv5/discover_test.go
+
+- CI integration
+  - https://github.com/waku-org/waku-interop-tests/actions/workflows/test_common.yml
+  - go_waku_daily which is now changed.
 

--- a/content/vac/qa/g/waku/test-automation-rln.md
+++ b/content/vac/qa/g/waku/test-automation-rln.md
@@ -22,7 +22,7 @@ gantt
   tickInterval 1month
   dateFormat YYYY-MM-DD 
   section Status
-    Test Automation RLN:  2024-01-01, 2024-03-31
+    Test Automation RLN:  2024-01-01, 2024-05-31
 ```
 
 - status: 40%

--- a/content/vac/qa/g/waku/test-automation-sharding.md
+++ b/content/vac/qa/g/waku/test-automation-sharding.md
@@ -22,16 +22,16 @@ gantt
   tickInterval 1month
   dateFormat YYYY-MM-DD 
   section Status
-    Test Automation Sharding:  2024-01-01, 2024-03-31
+    Test Automation Sharding:  2024-01-01, 2024-04-30
 ```
 
-- status: 30%
+- status: 50%
 - CC: Roman, Florin, Alex
 
 ### Description
 
 * nwaku unit tests
-* gowaku unit tests? (need to confirm if status uses sharding)
+* gowaku unit tests
 * js-waku unit tests
 * interop sharding tests
 

--- a/content/vac/qa/index.md
+++ b/content/vac/qa/index.md
@@ -4,7 +4,7 @@ tags:
 - dst
 - vac
 date: 2024-02-06
-lastmod: 2024-03-18
+lastmod: 2024-03-26
 ---
 
 ## `vac:qa::`
@@ -18,9 +18,10 @@ lastmod: 2024-03-18
 * [[vac/qa/g/waku/test-automation-nwaku|test-automation-nwaku ]]
 * [[vac/qa/g/waku/test-automation-rln|test-automation-rln ]]
 * [[vac/qa/g/waku/test-automation-sharding|test-automation-sharding ]]
-* [[vac/qa/g/waku/test-automation-go-waku|test-automation-go-waku ]]
+* [x] [[vac/qa/g/waku/test-automation-go-waku|test-automation-go-waku ]]
 * [[vac/qa/g/waku/interop-testing|interop-testing ]]
 * [[vac/qa/g/waku/maintenance-js-waku|maintenance-js-waku ]]
 * [[vac/qa/g/waku/maintenance-nwaku|maintenance-nwaku ]]
 * [[vac/qa/g/waku/maintenance-go-waku|maintenance-go-nwaku ]]
 * [[vac/qa/g/waku/ws-stress-testing|ws-stress-testing ]]
+* [[vac/qa/g/vac/test-automation-nim-libp2p|test-automation-nim-libp2p ]]


### PR DESCRIPTION
- Closed `test-automation-go-waku` milestone
- Extended the deadlines for sharding and rln milestone based on current assessment:
     - previous milestones took more than expected
     - we did extra work that was not planned
     - I've underestimated then amount of work needed and the number of issues found
- Added new milestone for automation on vac nim-libp2p side