### PR TITLE
docs: minor updates to AnonComms roadmap

### DIFF
--- a/content/anoncomms/furps/de-mls.md
+++ b/content/anoncomms/furps/de-mls.md
@@ -15,6 +15,8 @@
 5. An API spec is published that exposes de-MLS functionality and abstracts consensus
 6. De-MLS is implemented in Rust
 7. The De-MLS API is available in Rust and C
+8. De-MLS is included in the Chat SDK protocol stack specification
+9. De-MLS is integrated into a working ChatSDK module deployed to Logos Core
 
 ## Reliability
 

--- a/content/anoncomms/index.md
+++ b/content/anoncomms/index.md
@@ -14,6 +14,6 @@ lastmod: 2025-11-27
 
 The AnonComms team focus on the research and development of protocols related to anonymous communication in a decentralised setting.
 
-- [FURPS](./furps/)
-- [Roadmap](./roadmap/)
-- [Weekly Updates](./updates)
+- [[anoncomms/furps/index|FURPS]]
+- [[anoncomms/roadmap/index|Roadmap]]
+- [[anoncomms/updates/index|Weekly Updates]]

--- a/content/anoncomms/roadmap/create_basic_capability_discovery_module.md
+++ b/content/anoncomms/roadmap/create_basic_capability_discovery_module.md
@@ -5,7 +5,7 @@
 **Resources Required**:
 - 3 developers for 16 weeks
 
-A major cornerstone of the [Logos Launch Strategy](https://www.notion.so/Logos-Launch-Strategy-29d8f96fb65c81f4bbc9ffa45c6facc7#29d8f96fb65c81c2ac73c93b5cc2b476)
+A major cornerstone of the Logos Launch Strategy
 is the efficient discovery of core services in a fully decentralised manner.
 The current approach to decentralised discovery, random walks over libp2p's Kad-DHT
 is not scalable and efficient enough for a diverse ecosystem consisting of multiple services,

--- a/content/anoncomms/roadmap/deliver_de-mls_api.md
+++ b/content/anoncomms/roadmap/deliver_de-mls_api.md
@@ -84,6 +84,23 @@ Next steps not yet included in this milestone, include:
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
+### Specify and integrate de-MLS into ChatSDK
+
+**Owner**: AnonComms de-MLS
+
+**Feature**: [de-MLS FURPS](../furps/de-mls.md)
+
+**FURPS**:
+
+- U8. De-MLS is included in the Chat SDK protocol stack specification
+- U9. De-MLS is integrated into a working ChatSDK module deployed to Logos Core
+
+**Checklist**:
+- [ ] Specs: link to specs and/or API definition
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or other docs
+
 ### Separate Hashgraph-like consensus crate
 
 **Owner**: AnonComms de-MLS

--- a/content/anoncomms/roadmap/index.md
+++ b/content/anoncomms/roadmap/index.md
@@ -18,4 +18,8 @@ The AnonComms team is currently working on the following milestones:
 5. [Rework and deliver a public Zerokit 1.0 API](./deliver_public_zerokit_1.0_api.md) that improves usability and add big-endian support.
 6. [Release an RLN Prover to support gasless L2 transactions](./release-rln-prover_for_gasless_l2.md) on Status Network, including publishing a whitepaper.
 
+Of these, (1) and (2) are the team's current top priorities,
+as both capability discovery and mixifying libp2p protocols
+are critical for the launch of Logos.
+
 Visit each milestone for a detailed breakdown in separate deliverables.

--- a/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
+++ b/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
@@ -12,8 +12,9 @@ based on Karma balance.
 Within this milestone,
 the AnonComms team defined work as a service unit in aid of Status Network's requirements.
 However, the work here will have wider value for the Logos ecosystem,
-not least making RLN more flexible to allow burning multiple message IDs in a single proof,
-and a proven application of RLN for fair-use gasless transactions.
+not least in making RLN more flexible to allow burning multiple message IDs in a single proof,
+deploying a separate RLN prover module,
+and proving the application of RLN for fair-use gasless transactions.
 
 By the end of this milestone,
 we will have extended the RLN proving stack to support the burning of multiple message IDs in a single proof.

--- a/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
+++ b/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
@@ -9,6 +9,12 @@ We've previously merged the rln-prover to the
 [Status L2 monorepo](https://github.com/status-im/status-network-monorepo/pull/54) to support gasless L2 operations,
 based on Karma balance.
 
+Within this milestone,
+the AnonComms team defined work as a service unit in aid of Status Network's requirements.
+However, the work here will have wider value for the Logos ecosystem,
+not least making RLN more flexible to allow burning multiple message IDs in a single proof,
+and a proven application of RLN for fair-use gasless transactions.
+
 By the end of this milestone,
 we will have extended the RLN proving stack to support the burning of multiple message IDs in a single proof.
 We'll also enable multiple provers to operate on a shared database.

--- a/content/index.md
+++ b/content/index.md
@@ -14,4 +14,4 @@ Every year (starting this year), each project defines its plans in a number a mi
 - [[messaging/index|Messaging]]
 - [Codex](codex/overview.md)
 - [[nomos/index|Nomos]]
-
+- [[anoncomms/index|AnonComms]]


### PR DESCRIPTION
Made the following minor changes to the roadmap:

1. Addressed comments from previous PR: https://github.com/logos-co/roadmap/pull/265
- Add de-MLS integration + specification in ChatSDK (both in FURPS and as a new deliverable)
- remove link to internal Logos Strategy doc
- highlight top 2 priorities for team
- better motivation for SN service work
2. (Hopefully) fixed some links that was a bit funky on deployed site