### PR TITLE
docs: add GH links, minor update in zerokit description

### DIFF
--- a/content/anoncomms/roadmap/create_basic_capability_discovery_module.md
+++ b/content/anoncomms/roadmap/create_basic_capability_discovery_module.md
@@ -1,4 +1,4 @@
-# Create basic capability discovery module for Logos Core
+# [Create basic capability discovery module for Logos Core](https://github.com/logos-co/anoncomms-pm/milestone/1)
 
 **Estimated date of completion**: 31 Mar 2026
 
@@ -29,7 +29,7 @@ Next steps not yet included in this milestone, include:
 
 ## Deliverables
 
-### Specify basic capability discovery protocol
+### [Specify basic capability discovery protocol](https://github.com/logos-co/anoncomms-pm/issues/1)
 
 **Owner**: AnonComms Discovery
 
@@ -43,7 +43,7 @@ Next steps not yet included in this milestone, include:
 **Checklist**:
 - [ ] Specs: link to specs and/or API definition
 
-### Build PoC implementation of capability discovery protocol
+### [Build PoC implementation of capability discovery protocol](https://github.com/logos-co/anoncomms-pm/issues/2)
 
 **Owner**: AnonComms Discovery
 
@@ -59,7 +59,7 @@ U3. The PoC implementation contains instructions to allow open dogfooding
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
-### Specify and implement Kad-DHT discovery protocol and API
+### [Specify and implement Kad-DHT discovery protocol and API](https://github.com/logos-co/anoncomms-pm/issues/3)
 
 **Owner**: AnonComms Discovery
 

--- a/content/anoncomms/roadmap/deliver_de-mls_api.md
+++ b/content/anoncomms/roadmap/deliver_de-mls_api.md
@@ -1,4 +1,4 @@
-# Deliver de-MLS API supporting multi-stewards and advanced group management
+# [Deliver de-MLS API supporting multi-stewards and advanced group management](https://github.com/logos-co/anoncomms-pm/milestone/3)
 
 **Estimated date of completion**: 31 January 2026
 
@@ -30,7 +30,7 @@ Next steps not yet included in this milestone, include:
 
 ## Deliverables
 
-### Specify multi-steward and advanced group management protocol
+### [Specify multi-steward and advanced group management protocol](https://github.com/logos-co/anoncomms-pm/issues/6)
 
 **Owner**: AnonComms de-MLS
 
@@ -67,7 +67,7 @@ Next steps not yet included in this milestone, include:
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
-### Specify and implement de-MLS API
+### [Specify and implement de-MLS API](https://github.com/logos-co/anoncomms-pm/issues/5)
 
 **Owner**: AnonComms de-MLS
 
@@ -101,7 +101,7 @@ Next steps not yet included in this milestone, include:
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
-### Separate Hashgraph-like consensus crate
+### [Separate Hashgraph-like consensus crate](https://github.com/logos-co/anoncomms-pm/issues/4)
 
 **Owner**: AnonComms de-MLS
 

--- a/content/anoncomms/roadmap/deliver_public_zerokit_1.0_api.md
+++ b/content/anoncomms/roadmap/deliver_public_zerokit_1.0_api.md
@@ -1,4 +1,4 @@
-# Deliver public Zerokit 1.0 API with big-endian support
+# [Deliver public Zerokit 1.0 API with big-endian support](https://github.com/logos-co/anoncomms-pm/milestone/6)
 
 **Estimated date of completion**: 31 January 2026
 
@@ -11,7 +11,7 @@ that focus on RLN, developed in Rust, is intended for integration with various s
 Previously, we released Zerokit v0.9.0, which supports improved CI, optimized,
 partially BE support and research on FFI improvements.
 By the end of this milestone, we will deliver Zerokit v1 and begin advancing the next version.
-This includes big-endian support, an improved FFI interface and multi-id burnt support.
+This includes big-endian support and an improved FFI interface.
 
 ## Risks
 
@@ -21,7 +21,7 @@ This includes big-endian support, an improved FFI interface and multi-id burnt s
 
 ## Deliverables
 
-### Rework Zerokit WASM FFI
+### [Rework Zerokit WASM FFI](https://github.com/logos-co/anoncomms-pm/issues/7)
 
 **Owner**: AnonComms Zerokit-RLN
 
@@ -38,7 +38,7 @@ This includes big-endian support, an improved FFI interface and multi-id burnt s
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
-### Rework Zerokit Public API
+### [Rework Zerokit Public API](https://github.com/logos-co/anoncomms-pm/issues/8)
 
 **Owner**: AnonComms Zerokit-RLN
 

--- a/content/anoncomms/roadmap/establish_libp2p_mixnet.md
+++ b/content/anoncomms/roadmap/establish_libp2p_mixnet.md
@@ -1,4 +1,4 @@
-# Establish libp2p mixnet for Logos Core
+# [Establish libp2p mixnet for Logos Core](https://github.com/logos-co/anoncomms-pm/milestone/2)
 
 **Estimated date of completion**: 31 Mar 2026
 
@@ -33,7 +33,7 @@ Next steps not yet included in this milestone (see [Roadmap deliverable](#publis
 
 ## Deliverables 
 
-### Specify DoS and Sybil protection protocol for libp2p mix
+### [Specify DoS and Sybil protection protocol for libp2p mix](https://github.com/logos-co/anoncomms-pm/issues/9)
 
 **Owner**: AnonComms Mix
 

--- a/content/anoncomms/roadmap/implement_mvp_payment_protocol.md
+++ b/content/anoncomms/roadmap/implement_mvp_payment_protocol.md
@@ -1,4 +1,4 @@
-# Implement MVP payment protocol
+# [Implement MVP payment protocol](https://github.com/logos-co/anoncomms-pm/milestone/5)
 
 **Estimated date of completion**: 31 Mar 2026
 
@@ -20,7 +20,7 @@ By the end of this milestone, we will have specified and implemented a privacy-p
 
 ## Deliverables
 
-### Specify MVP payment protocol
+### [Specify MVP payment protocol](https://github.com/logos-co/anoncomms-pm/issues/10)
 
 **Owner**: AnonComms Incentivisation
 

--- a/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
+++ b/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
@@ -1,4 +1,4 @@
-# Release RLN Prover for gasless L2 transactions
+# [Release RLN Prover for gasless L2 transactions](https://github.com/logos-co/anoncomms-pm/milestone/4)
 
 **Estimated date of completion**: 31 January 2026
 
@@ -30,7 +30,7 @@ culminating in a whitepaper describing the RLN prover approach to gasless L2 tra
 
 ## Deliverables
 
-### Allow multiple RLN provers to share a database
+### [Allow multiple RLN provers to share a database](https://github.com/logos-co/anoncomms-pm/issues/11)
 
 **Owner**: AnonComms Zerokit-RLN
 
@@ -65,7 +65,7 @@ culminating in a whitepaper describing the RLN prover approach to gasless L2 tra
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
-### Write whitepaper on gasless L2 transactions
+### [Write whitepaper on gasless L2 transactions](https://github.com/logos-co/anoncomms-pm/issues/12)
 
 **Owner**: AnonComms Zerokit-RLN
 


### PR DESCRIPTION
- Added Github links for milestones and open deliverables
- Updated Zerokit v1.0 description not to commit to inclusion of multi-id burning