### PR TITLE
docs: add demo chat app to mix deliverables

### DIFF
--- a/content/anoncomms/furps/mix.md
+++ b/content/anoncomms/furps/mix.md
@@ -14,6 +14,8 @@
 2. The libp2p mix protocol with DoS and Sybil protection is integrated in nim-libp2p
 3. The libp2p mix protocol with DoS and Sybil protection is integrated into Waku Lightpush protocol as reference integration
 4. A libp2p module with mix capability is integrated into Logos Core
+5. A Logos Core demo chat app showcases message publishing over libp2p mix
+6. The Logos Core demo chat app discovers mix nodes using libp2p kad-dht discovery with filtering
 
 ## Reliability
 

--- a/content/anoncomms/roadmap/establish_libp2p_mixnet.md
+++ b/content/anoncomms/roadmap/establish_libp2p_mixnet.md
@@ -33,6 +33,29 @@ Next steps not yet included in this milestone (see [Roadmap deliverable](#publis
 
 ## Deliverables 
 
+### Create demo chat app in Logos Core for messaging over libp2p mix
+
+**Owner**: AnonComms Mix
+
+**Feature**: [Mix](../furps/mix.md)
+
+**FURPS**:
+
+- U5. A Logos Core demo chat app showcases message publishing over libp2p mix
+- U6. The Logos Core demo chat app discovers mix nodes using libp2p kad-dht discovery with filtering
+
+**Notes**:
+
+This deliverable is aimed for inclusion in the Logos testnet in Feb 2026.
+It showcases basic publishing over mix for Logos Core,
+and building mix paths using libp2p kad-dht as underlying discovery mechanism.
+Sybil and DoS protection is out of scope for this deployment.
+
+**Checklist**:
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or other docs
+
 ### [Specify DoS and Sybil protection protocol for libp2p mix](https://github.com/logos-co/anoncomms-pm/issues/9)
 
 **Owner**: AnonComms Mix
@@ -45,7 +68,6 @@ Next steps not yet included in this milestone (see [Roadmap deliverable](#publis
 
 **Checklist**:
 - [ ] Specs: link to specs and/or API definition
-
 
 ### Implement DoS and Sybil protection protocol for libp2p mix
 


### PR DESCRIPTION
As discussed, adding a deliverable for a Logos Core "demo chat" app that showcases publishing over a mix layer (and discovery + filtering using libp2p kad-dht).
This is aimed for the Feb 2026 Logos testnet.

Once merged I'll create a corresponding deliverable GH issue.
Note that this will likely just copy the existing [logos chat module](https://github.com/logos-co/logos-chat-module) with a modified Messaging library (to use lightpush+mix publishing and the soon-to-exist kad-dht discovery).