### PR TITLE
docs: add FURPS and milestone Authenticated connection 

### DIFF
--- a/content/anoncomms/furps/zerokit-rln.md
+++ b/content/anoncomms/furps/zerokit-rln.md
@@ -17,6 +17,7 @@
 ## Reliability
 
 1. Multiple RLN prover instances operate consistently without database conflicts
+2. Decentralized slashers establish authenticated connections to the RLN prover to observe proofs and detect spam
 
 ## Performance
 

--- a/content/anoncomms/furps/zerokit-rln.md
+++ b/content/anoncomms/furps/zerokit-rln.md
@@ -6,6 +6,7 @@
 2. Multiple RLN prover instances can operate on a shared database
 3. An RLN prover can burn multiple message-ids in a single proof
 4. The Zerokit module supports big-endian operations
+5. The RLN prover module supports authenticated slasher connections using a statically configured authentication mechanism
 
 ## Usability
 

--- a/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
+++ b/content/anoncomms/roadmap/release-rln-prover_for_gasless_l2.md
@@ -77,3 +77,19 @@ culminating in a whitepaper describing the RLN prover approach to gasless L2 tra
 
 **Checklist**:
 - [ ] Docs: link to whitepaper
+
+### Authenticated connections between prover and slashers
+
+**Owner**: AnonComms Zerokit-RLN
+
+**Feature**: [Zerokit-RLN FURPS](../furps/zerokit-rln.md)
+
+**FURPS**:
+
+- R2. Decentralized slashers establish authenticated connections to the RLN prover to observe proofs and detect spam
+
+**Checklist**:
+- [ ] Specs: link to specs and/or API definition
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or other docs


### PR DESCRIPTION
In gasless L2, we have 128 decentralized slashers that need to listen to the prover module to detect spam. Due to the efficiency issues we cannot let them be more than 128, so we need to restrict the connection between prover <> slashers. 

This PR is adding the milestone for creating this authenticated connection. 