### PR TITLE
docs(anoncomms): Update the estimated date of completion of de-MLS

### DIFF
--- a/content/anoncomms/roadmap/deliver_de-mls_api.md
+++ b/content/anoncomms/roadmap/deliver_de-mls_api.md
@@ -1,6 +1,6 @@
 # [Deliver de-MLS API supporting multi-stewards and advanced group management](https://github.com/logos-co/anoncomms-pm/milestone/3)
 
-**Estimated date of completion**: 31 January 2026
+**Estimated date of completion**: 31 March 2026
 
 **Resources Required**:
 - 2 developers for 10 weeks


### PR DESCRIPTION
Since the hashgraph separation and subsequent re-integration into the de-MLS codebase required more time than initially exptected, I propose to postpone the de-MLS delivery to the end of March.