### PR TITLE
fix: PageList sorting date

### DIFF
--- a/quartz/components/PageList.tsx
+++ b/quartz/components/PageList.tsx
@@ -26,7 +26,9 @@ export function byDateAndAlphabetical(
   cfg: GlobalConfiguration,
 ): (f1: QuartzPluginData, f2: QuartzPluginData) => number {
   const getComparableDate = (file: QuartzPluginData): Date | null => {
+    console.log("Getting comparable date for file:", file.frontmatter?.title, file.dates)
     return (
+      file.dates?.created ??
       file.dates?.published ??
       extractDateFromTitle(file.frontmatter?.title ?? "") ??
       extractDateFromSlug(file.slug) ??


### PR DESCRIPTION
# Issue description

The sorting of folder items in the `Weekly Updates` folders was done by `publishDate`, but we have `date` (created date) in the documents, so the sorting is messed up, making the latest updates appear in the center of the page.

<img height="600" alt="image" src="https://github.com/user-attachments/assets/bf274fb5-ec68-4bcc-8eca-616524ccba42" />

# Fix

The fix is simple, we change the sorting from `published` to `date`.

It's not ideal, because I modified the original source code. But it is as a very straightforward singleliner, so I would go with it, rather than modifying 403 documents `date` fields.

This is similar to what `Hugo` was configured to do:
https://github.com/logos-co/roadmap/blob/3dea943450b62f7c567aa08f5f5a5639c44e4d78/config.toml#L30-L32

<img height="600" alt="image" src="https://github.com/user-attachments/assets/45fcc71b-e375-4e69-b2c7-7898a1ee1a84" />
