### PR TITLE
ci: simple build-test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Verify Build
+
+on:
+  push:
+    branches: [ v4 ]
+  pull_request:
+    branches: [ v4 ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npx quartz build
+
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
# Description

The `v4` branch is completely unprotected now. I accidentally merged a document with typo which was not compiling.
This job would prevent this from happening (tested)

Next steps:
- [x] Require a PR (forbid pushing to `v4`)
- [x] Mark the job as required for merging