### PR TITLE
docs(anoncomms): Updating the roadmap and FURPS by replacing authenticated connection to aggregator node

### DIFF
--- a/content/anoncomms/furps/zerokit-rln.md
+++ b/content/anoncomms/furps/zerokit-rln.md
@@ -6,7 +6,7 @@
 2. Multiple RLN prover instances can operate on a shared database
 3. An RLN prover can burn multiple message-ids in a single proof
 4. The Zerokit module supports big-endian operations
-5. The RLN prover module supports a statically configured authentication mechanism for slasher connections
+5. The RLN prover module supports proof output streaming to an aggregator node
 
 ## Usability
 
@@ -18,7 +18,7 @@
 ## Reliability
 
 1. Multiple RLN prover instances operate consistently without database conflicts
-2. Authenticated slasher connections remain stable and do not interfere with proof generation or database consistency.
+2. The aggregator relays RLN proof metadata to decentralized slashers
 3. Decentralized slashers extract the secret from double-signaled (spammed) proofs to enable slashing
 
 ## Performance

--- a/content/anoncomms/roadmap/extend_gasless_L2_transactions_with_multi-burn_RLN_and_decentralized_slashing.md
+++ b/content/anoncomms/roadmap/extend_gasless_L2_transactions_with_multi-burn_RLN_and_decentralized_slashing.md
@@ -41,7 +41,7 @@ All components will be fully specified.
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
-### [Authenticated connections between prover and slashers](https://github.com/logos-co/anoncomms-pm/issues/16)
+### [Implementation of aggregator-slasher architecture](https://github.com/logos-co/anoncomms-pm/issues/16)
 
 **Owner**: AnonComms Zerokit-RLN
 
@@ -49,8 +49,8 @@ All components will be fully specified.
 
 **FURPS**:
 
-- F5. The RLN prover module supports a statically configured authentication mechanism for slasher connections
-- R2. Decentralized slashers establish authenticated connections to the RLN prover to observe proofs and detect spam
+- F5. The RLN prover module supports proof output streaming to an aggregator node
+- R2. The aggregator relays RLN proof metadata to decentralized slashers
 - R3. Decentralized slashers extract the secret from double-signaled (spammed) proofs to enable slashing
 
 **Checklist**:


### PR DESCRIPTION
Recently, we concluded that we can replace the authentication connection then introduce the aggregator node for better efficiency. This PR updates the modification on roadmap and FURPS. 

Also I updated the [deliverable16](https://github.com/logos-co/anoncomms-pm/issues/16) too. 