### PR TITLE
docs(storage): update roadmap to reflect current work

### DIFF
--- a/content/storage/roadmap/index.md
+++ b/content/storage/roadmap/index.md
@@ -30,6 +30,7 @@ In addition, the team is also working on the following post-mainnet features:
 
 - [ ] [[v0.2-filesharing | Scalable, Simple Filesharing v0.2 Deliverables]]
 - [ ] [[v0.2-privacy-preserving-filesharing | Privacy-Preserving Filesharing v0.2 Deliverables]]
+- [ ] [[v0.2-logos-core-integration | Logos Core Integration v0.2 Deliverables]]
 
 ### Testnet [v0.3](v03)
 

--- a/content/storage/roadmap/tracks/v0.2-filesharing.md
+++ b/content/storage/roadmap/tracks/v0.2-filesharing.md
@@ -16,3 +16,11 @@ A simpler, faster, more predictable and easier to understand block protocol for 
 **FURPS**: [Enhanced Filesharing Protocol](enhanced-filesharing-protocol)
 
 1. Covers all aspects of it.
+
+### 2. [Better NAT Traversal](https://github.com/logos-storage/logos-storage-pm/issues/5)
+
+Logos Storage needs better support for traversing NATs. This deliverable is about leveraging the full capabilities offered by libp2p to provide easier-to-configure (or zero-config, depending on the case) networking.
+
+**FURPS**: [Serving Frontends, Modules, and Files](frontends-filesharing)
+
+1. [U3]: **Zero-config networking.** Within the possibilities of current technology, user should not have to take any extra steps; e.g. opening ports on a router, to get file sharing working.[^1]

--- a/content/storage/roadmap/tracks/v0.2-logos-core-integration.md
+++ b/content/storage/roadmap/tracks/v0.2-logos-core-integration.md
@@ -1,0 +1,7 @@
+# Logos Core Track: Testnet v0.1
+
+## Deliverables
+
+# Logos Module Updates
+
+Logos Core is undergoing constant changes. We will deliver up-to-date core and UI storage modules which track the latest developments.

--- a/content/storage/roadmap/tracks/v0.2-privacy-preserving-filesharing.md
+++ b/content/storage/roadmap/tracks/v0.2-privacy-preserving-filesharing.md
@@ -1,8 +1,8 @@
 # Privacy-Preserving Filesharing Track: Testnet v0.2
 
-## 1. [Large Data Transport Layer for Mix](https://github.com/logos-storage/logos-storage-pm/issues/2)
+## 1. [Large Data Transport Layer for Mix: Spec and Reference Implementation](https://github.com/logos-storage/logos-storage-pm/issues/15)
 
-Mixnets work on small, fixed packet sizes. They also assume some level of symmetry in traffic sent and received. We need to haul larger files - small request, large response, large data. This is about building an abstraction on top of Mix to enable that.
+Mixnets work on small, fixed packet sizes. They also assume some level of symmetry in traffic sent and received. We need to haul larger files - small request, large response, large data. We will provide an abstraction which allows establishing bidirectional, ordered, reliable streams over Mix. For v0.2, we will deliver the initial spec, and a reference implementation.
 
 **FURPS:** [[large-data-transport-layer-for-mix | Large-Data "Transport Layer" for Mix]]
 
@@ -12,8 +12,18 @@ Privacy-preserving filesharing requires DHT queries to be anonymous. As a first 
 
 **FURPS:** [[anonymous-dht-queries | Anonymous DHT Queries]]
 
-## 3. [Anonymous Downloads](https://github.com/logos-storage/logos-storage-pm/issues/4)
+## 3. [Anonymous Providers: Spec](https://github.com/logos-storage/logos-storage-pm/issues/5)
 
-Using the results from (1), we want to adapt our revamped download protocol to run over a mixnet. At first, we will only deal with making downloads unlinkable; i.e., nodes downloading a file should not be linkable to the content they are downloading. Providers remain exposed.
+**FURPS:** [[privacy-preserving-filesharing-furps | Serving Frontends, Modules, and Files in a Privacy-Preserving Fashion]]
 
-**FURPS:** [[anonymous-downloads | Anonymous Downloads]]
+1. [S1]: Neither **the identity of publishers** nor that of downloaders should be revealed to other participants; i.e., we want full publisher and downloader unlinkability. This includes queries.
+
+Mixnets are good at hiding the originator of a message, but the destinations remains exposed. This is a problem for filesharing because it means nodes requesting data can be unlinked, but the ones providing it cannot. This deliverable is about providing anonimity to providers as well. This will likely be based on some variation of techniques seen in Tribler[^1], but adapted for mixnets.
+
+For v0.2, we intend to deliver a first draft spec.
+
+## 4. Improvements to Mix
+
+Collaboration with Anonymous Comms in improving the Mix network implementation.
+
+* [LIONESS spec](https://github.com/logos-storage/logos-storage-pm/issues/14): LIONESS will replace the AES-CTR implementation used in Mix payloads.

--- a/content/storage/roadmap/tracks/v0.3-privacy-preserving-filesharing.md
+++ b/content/storage/roadmap/tracks/v0.3-privacy-preserving-filesharing.md
@@ -1,13 +1,21 @@
 # Privacy-Preserving Filesharing Track: Testnet v0.3
 
-## 1. [Anonymous Providers](https://github.com/logos-storage/logos-storage-pm/issues/5)
+## 1. [Large Data Transport Layer for Mix: Working Implementation](https://github.com/logos-storage/logos-storage-pm/issues/2)
+
+Based on the transport layer draft spec and reference implementation, we will build a Nim implementation in nim-libp2p.
+
+**FURPS:** [[large-data-transport-layer-for-mix | Large-Data "Transport Layer" for Mix]]
+
+## 2. [Anonymous Downloads](https://github.com/logos-storage/logos-storage-pm/issues/4)
+
+Using the results from (1), we want to adapt our revamped download protocol to run over a mixnet. At first, we will only deal with making downloads unlinkable; i.e., nodes downloading a file should not be linkable to the content they are downloading. Providers remain exposed.
+
+**FURPS:** [[anonymous-downloads | Anonymous Downloads]]
+
+## 3. [Anonymous Providers: Implementation](https://github.com/logos-storage/logos-storage-pm/issues/5)
 
 **FURPS:** [[privacy-preserving-filesharing-furps | Serving Frontends, Modules, and Files in a Privacy-Preserving Fashion]]
 
-1. [S1]: Neither **the identity of publishers** nor that of downloaders should be revealed to other participants; i.e., we want full publisher and downloader unlinkability. This includes queries.
-
-[Anonymous downloads](v0.2-privacy-preserving-filesharing.md#3-anonymous-downloads) gave us unlinkability for downloads, but providers are still exposed. This deliverable closes that gap by making providers anonymous as well. This will likely be based on some variation of techniques seen in Tribler[^1], but adapted for mixnets.
-
-Once this is in place, Logos Storage should be able to provide fully anonymous filesharing.
+This deliverable is about implementing the anonymous provider spec in the filesharing client itself. Together with anonymous downloads and anonyous queries, this should provide full unlinkability for both downloaders and providers.
 
 [^1]: https://github.com/Tribler/tribler/wiki/Anonymous-Downloading-and-Streaming-specifications


### PR DESCRIPTION
This PR updates the current roadmap so it reflects the work we're doing. In particular it includes:

* the work on NAT traversal;
* the continuing work on Logos Modules;
* some of the work that's being done with anon comms.

It also splits some of the deliverables (e.g. transport layer) into specs/ref. implementation, and the Nim implementation which should follow after that.