### PR TITLE
docs(anoncomms): add identity track

### DIFF
--- a/content/anoncomms/furps/identity.md
+++ b/content/anoncomms/furps/identity.md
@@ -2,28 +2,24 @@
 
 ## Functionality
 
-1. An identity is bound to at least one cryptographic key whose private part is controlled by the holder.
-2. An identity has a stable, long-lived address that does not change when keys rotate or are revoked.
-3. An identity carries an append-only operation log of credential changes.
-4. An identity can be created without permission from any third party.
-5. An identity can hold one or more installation keys.
-6. A new installation can be added to an identity by an authorised current installation.
-7. An installation can be revoked by an authorised current installation.
-8. An identity is consumable by de-MLS to retrieve the key package for an active installation.
-9. Identity creation is resistant to trivial Sybil attacks.
-10. An identity can be discovered by contacts via address share and registry lookup.
+1. An account is bound to at least one cryptographic key whose private part is controlled by the holder.
+2. An account has a stable, long-lived address that does not change when keys rotate or are revoked.
+3. An account carries an append-only operation log of credential changes.
+4. An account can be created without permission from any third party.
+5. An account can hold one or more keys.
+6. A new key can be added to an account by the account holder.
+7. A key can be revoked by the account holder.
+8. Given an account address, anyone can query for the associated keys.
 
 <!-- ──────── post-mainnet ──────── -->
 
-11. An identity can hold one or more associations to externally owned identifiers (EoIs).
-12. An identity holder controls which EoIs are disclosed to which counterparty.
-13. An identity can be used to sign in to Logos services using CAIP-122.
-14. An identity supports holder-defined recovery policies (e.g. social recovery).
-15. An identity's operation log supports programmable validation policies, defined by the holder, that govern which mutations are accepted (i.e., full provenance log implementation).
+9. Account creation is resistant to trivial Sybil attacks.
+10. An account allows for associating externally owned identifiers (EoIs) to be used as alternative addresses.
+11. An account supports programmable validation policies, defined by the holder, that govern which mutations are accepted (i.e., full provenance log implementation)
 
 ## Usability
 
-1. The basic identity protocol (address format, operation log, contact discovery flow) is published in a specification.
+1. The basic identity protocol (accounts, address format, operation log, contact discovery flow) is published in a specification.
 2. The registry interface (lookup, write authorisation) is published in a specification.
 3. The identity library is implemented in Rust.
 4. The identity library is available via C-bindings.
@@ -35,15 +31,17 @@
 
 8. The EoI format and disclosure model is published in a specification.
 9. The CAIP-122 binding for Logos identities is published in a specification.
-10. Holder-defined identity recovery policies are published in a specification.
+10. Holder-defined account recovery policies are published in a specification.
 11. The provenance log protocol is published in a specification.
 
 ## Reliability
 
+1. Account operation logs are durably stored forever in a registry.
+
 ## Performance
 
-1. A registry lookup of an identity's current state completes within a bounded time under typical network conditions.
-2. Identity creation completes within a few seconds on a typical client.
+1. A registry lookup of an account's current state completes within a bounded time under typical network conditions.
+2. Account creation completes within a few seconds on a typical client.
 
 ## Supportability
 

--- a/content/anoncomms/furps/identity.md
+++ b/content/anoncomms/furps/identity.md
@@ -1,0 +1,51 @@
+# Identity FURPS
+
+## Functionality
+
+1. An identity is bound to at least one cryptographic key whose private part is controlled by the holder.
+2. An identity has a stable, long-lived address that does not change when keys rotate or are revoked.
+3. An identity carries an append-only operation log of credential changes.
+4. An identity can be created without permission from any third party.
+5. An identity can hold one or more installation keys.
+6. A new installation can be added to an identity by an authorised current installation.
+7. An installation can be revoked by an authorised current installation.
+8. An identity is consumable by de-MLS to retrieve the key package for an active installation.
+9. Identity creation is resistant to trivial Sybil attacks.
+10. An identity can be discovered by contacts via address share and registry lookup.
+
+<!-- ──────── post-mainnet ──────── -->
+
+11. An identity can hold one or more associations to externally owned identifiers (EoIs).
+12. An identity holder controls which EoIs are disclosed to which counterparty.
+13. An identity can be used to sign in to Logos services using CAIP-122.
+14. An identity supports holder-defined recovery policies (e.g. social recovery).
+15. An identity's operation log supports programmable validation policies, defined by the holder, that govern which mutations are accepted (i.e., full provenance log implementation).
+
+## Usability
+
+1. The basic identity protocol (address format, operation log, contact discovery flow) is published in a specification.
+2. The registry interface (lookup, write authorisation) is published in a specification.
+3. The identity library is implemented in Rust.
+4. The identity library is available via C-bindings.
+5. The identity library is integrated into a working Logos Chat module deployed to Logos Core.
+6. The registry is implemented as an LEZ program.
+
+<!-- ──────── post-mainnet ──────── -->
+
+7. The EoI format and disclosure model is published in a specification.
+8. The CAIP-122 binding for Logos identities is published in a specification.
+9. Holder-defined identity recovery policies are published in a specification.
+10. The provenance log protocol is published in a specification.
+
+## Reliability
+
+## Performance
+
+1. A registry lookup of an identity's current state completes within a bounded time under typical network conditions.
+2. Identity creation completes within a few seconds on a typical client.
+
+## Supportability
+
+## Miscellaneous dependencies
+
+1. Dependency on performant LEZ for the V1 registry backend.

--- a/content/anoncomms/furps/identity.md
+++ b/content/anoncomms/furps/identity.md
@@ -28,14 +28,15 @@
 3. The identity library is implemented in Rust.
 4. The identity library is available via C-bindings.
 5. The identity library is integrated into a working Logos Chat module deployed to Logos Core.
-6. The registry is implemented as an LEZ program.
+6. The registry is implemented on the Logos Blockchain (as an LEZ program or as a dedicated Identity Zone).
+7. The registry backend choice on the Logos Blockchain (LEZ program vs dedicated Identity Zone) is evaluated and documented.
 
 <!-- ──────── post-mainnet ──────── -->
 
-7. The EoI format and disclosure model is published in a specification.
-8. The CAIP-122 binding for Logos identities is published in a specification.
-9. Holder-defined identity recovery policies are published in a specification.
-10. The provenance log protocol is published in a specification.
+8. The EoI format and disclosure model is published in a specification.
+9. The CAIP-122 binding for Logos identities is published in a specification.
+10. Holder-defined identity recovery policies are published in a specification.
+11. The provenance log protocol is published in a specification.
 
 ## Reliability
 
@@ -48,4 +49,4 @@
 
 ## Miscellaneous dependencies
 
-1. Dependency on performant LEZ for the V1 registry backend.
+1. Dependency on a performant Logos Blockchain backend for the V1 registry.

--- a/content/anoncomms/furps/identity.md
+++ b/content/anoncomms/furps/identity.md
@@ -7,15 +7,16 @@
 3. An account carries an append-only operation log of credential changes.
 4. An account can be created without permission from any third party.
 5. An account can hold one or more keys.
-6. A new key can be added to an account by the account holder.
-7. A key can be revoked by the account holder.
+6. A new key can be added to an account
+7. A key can be revoked from the account.
 8. Given an account address, anyone can query for the associated keys.
+9. Single-key compromise must not permit irreversible account takeover.
 
 <!-- ──────── post-mainnet ──────── -->
 
-9. Account creation is resistant to trivial Sybil attacks.
-10. An account allows for associating externally owned identifiers (EoIs) to be used as alternative addresses.
-11. An account supports programmable validation policies, defined by the holder, that govern which mutations are accepted (i.e., full provenance log implementation)
+10. Account creation is resistant to trivial Sybil attacks.
+11. An account allows for associating externally owned identifiers (EoIs) to be used as alternative addresses.
+12. An account supports programmable validation policies, defined by the holder, that govern which mutations are accepted (i.e., full provenance log implementation)
 
 ## Usability
 

--- a/content/anoncomms/roadmap/identity.md
+++ b/content/anoncomms/roadmap/identity.md
@@ -1,0 +1,45 @@
+# Identity Track
+
+Identity is a foundational protocol primitive
+that AnonComms tracks and develops in collaboration with a cross-section of Logos teams.
+The initial development focuses on the needs of Logos Chat,
+but will grow to address requirements by Blockchain (LEZ-account binding), Storage,
+and any service that needs Sybil-resistant or stable references to a holder.
+
+The aim of this track is to deliver a minimal but extensible identity primitive (λAccount)
+based on a Very Long-lived Address (VLAD) and an append-only operation log of keys,
+with the operation log stored in a registry backed by the Logos Execution Zone (LEZ).
+
+The mainnet target is deliberately minimal:
+future-proofed VLADs as the index into an LEZ-backed registry
+where each entry is a log of keys for the corresponding VLAD.
+This is enough to support multi-installation and key revocation
+while leaving room for richer features to be layered in post-mainnet
+without breaking existing addresses or registries.
+
+The Messaging Chat team owns the libchat-side implementation and has work in flight.
+The AnonComms Identity track formally tracks the cross-cutting design
+and consolidates the deliverables for mainnet and post-mainnet milestones.
+
+## Roadmap
+
+**FURPS**: [Identity FURPS](/anoncomms/furps/identity.md)
+
+**Scheduled milestones**:
+- [Testnet v0.2](/anoncomms/roadmap/testnet_v0.2/identity_v0.2.md)
+- [Testnet v0.3](/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md)
+- [Mainnet](/anoncomms/roadmap/mainnet/identity_mainnet.md)
+
+**Post-mainnet** features layered on top of the basic identity protocol, without changing existing addresses:
+1. External Identifier Associations (EoIs) and consent-based disclosure
+2. CAIP-122 sign-in flow
+3. Advanced λAccount: full provenance log (plog) with WACC verification scripts and λStorage backend
+4. Programmable validation policies including social recovery
+5. Post-quantum signatures (ML-DSA-65)
+6. Privacy upgrade: encrypted log content and Mix-routed lookups by default
+
+## Risks
+
+| Risk | (Accept, Own, Mitigation) |
+|------|----------------------------|
+| LEZ-as-Registry feasibility may surface blockers (storage cost, write throughput, indexing) that push mainnet features later than planned | Spike in v0.2; if blockers found, fall back to a DHT-backed registry (built on AnonComms Discovery) and re-baseline timeline |

--- a/content/anoncomms/roadmap/mainnet/identity_mainnet.md
+++ b/content/anoncomms/roadmap/mainnet/identity_mainnet.md
@@ -25,10 +25,10 @@ and key revocation.
 **Owner**: Messaging Chat (primary), AnonComms Identity (review)
 
 **FURPS**:
-- F9. Identity creation is resistant to trivial Sybil attacks.
 - U6. The registry is implemented on the Logos Blockchain (as an LEZ program or as a dedicated Identity Zone).
-- P1. A registry lookup of an identity's current state completes within a bounded time under typical network conditions.
-- P2. Identity creation completes within a few seconds on a typical client.
+- R1. Account operation logs are durably stored forever in a registry.
+- P1. A registry lookup of an account's current state completes within a bounded time under typical network conditions.
+- P2. Account creation completes within a few seconds on a typical client.
 
 **Checklist**:
 - [ ] Code: link to GitHub issues/PRs/Epic

--- a/content/anoncomms/roadmap/mainnet/identity_mainnet.md
+++ b/content/anoncomms/roadmap/mainnet/identity_mainnet.md
@@ -1,0 +1,30 @@
+# [Identity Track: Mainnet](TBD: anoncomms-pm milestone)
+
+**Track:** [Identity Track](/anoncomms/roadmap/identity.md)
+
+**FURPS:** [Identity FURPS](/anoncomms/furps/identity.md)
+
+**Estimated date of completion**: mainnet launch
+
+**Resources Required**:
+- 1 AnonComms engineer for protocol hardening
+- Messaging Chat team
+
+This milestone hardens the v0.3 implementation with LEZ-backing for the registry,
+focuses on production quality and ships the deliberately minimal basic identity scheme:
+future-proofed VLAD as the index,
+LEZ-backed registry,
+per-VLAD log of keys,
+multi-installation support,
+and key revocation.
+
+## Deliverables
+
+### [Mainnet deployment with LEZ-backed registry](TBD)
+
+**Owner**: Messaging Chat (primary), AnonComms Identity (review)
+
+- F9. Identity creation is resistant to trivial Sybil attacks.
+- U6. The registry is implemented as an LEZ program.
+- P1. A registry lookup of an identity's current state completes within a bounded time under typical network conditions.
+- P2. Identity creation completes within a few seconds on a typical client.

--- a/content/anoncomms/roadmap/mainnet/identity_mainnet.md
+++ b/content/anoncomms/roadmap/mainnet/identity_mainnet.md
@@ -10,21 +10,27 @@
 - 1 AnonComms engineer for protocol hardening
 - Messaging Chat team
 
-This milestone hardens the v0.3 implementation with LEZ-backing for the registry,
+This milestone hardens the v0.3 implementation with a Logos Blockchain-backed registry,
 focuses on production quality and ships the deliberately minimal basic identity scheme:
 future-proofed VLAD as the index,
-LEZ-backed registry,
+Logos Blockchain-backed registry,
 per-VLAD log of keys,
 multi-installation support,
 and key revocation.
 
 ## Deliverables
 
-### [Mainnet deployment with LEZ-backed registry](TBD)
+### [Mainnet deployment with Logos Blockchain-backed registry](TBD)
 
 **Owner**: Messaging Chat (primary), AnonComms Identity (review)
 
+**FURPS**:
 - F9. Identity creation is resistant to trivial Sybil attacks.
-- U6. The registry is implemented as an LEZ program.
+- U6. The registry is implemented on the Logos Blockchain (as an LEZ program or as a dedicated Identity Zone).
 - P1. A registry lookup of an identity's current state completes within a bounded time under typical network conditions.
 - P2. Identity creation completes within a few seconds on a typical client.
+
+**Checklist**:
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or other docs

--- a/content/anoncomms/roadmap/testnet_v0.2/identity_v0.2.md
+++ b/content/anoncomms/roadmap/testnet_v0.2/identity_v0.2.md
@@ -22,7 +22,7 @@ and validates the LEZ-as-Registry approach via a spike.
 **Owner**: Messaging Chat (primary), AnonComms Identity (review)
 
 **FURPS**:
-- U1. The basic identity protocol (address format, operation log, contact discovery flow) is published in a specification.
+- U1. The basic identity protocol (accounts, address format, operation log, contact discovery flow) is published in a specification.
 
 **Checklist**:
 - [ ] Specs: link to specs and/or API definition
@@ -32,7 +32,7 @@ and validates the LEZ-as-Registry approach via a spike.
 **Owner**: Messaging Chat
 
 **FURPS**:
-- P1. A registry lookup of an identity's current state completes within a bounded time under typical network conditions.
+- P1. A registry lookup of an account's current state completes within a bounded time under typical network conditions.
 
 **Checklist**:
 - [ ] Docs: links to README.md or other docs
@@ -42,7 +42,7 @@ and validates the LEZ-as-Registry approach via a spike.
 **Owner**: Messaging Chat
 
 **FURPS**:
-- F1. An identity is bound to at least one cryptographic key whose private part is controlled by the holder.
+- F1. An account is bound to at least one cryptographic key whose private part is controlled by the holder.
 
 **Checklist**:
 - [ ] Code: link to GitHub issues/PRs/Epic

--- a/content/anoncomms/roadmap/testnet_v0.2/identity_v0.2.md
+++ b/content/anoncomms/roadmap/testnet_v0.2/identity_v0.2.md
@@ -1,0 +1,50 @@
+# [Identity Track: Testnet v0.2](TBD: anoncomms-pm milestone)
+
+**Track:** [Identity Track](/anoncomms/roadmap/identity.md)
+
+**FURPS:** [Identity FURPS](/anoncomms/furps/identity.md)
+
+**Estimated date of completion**: 30 Jun 2026
+
+**Resources Required**:
+- 1 AnonComms researcher for spec review and cross-team coordination
+- Messaging Chat team ownership of libchat-side deliverables (see below)
+
+This milestone consolidates in-flight identity work into a tracked AnonComms protocol concern,
+establishes the cross-team specification scaffolding,
+locks in a future-proofed VLAD-compatible address format,
+and validates the LEZ-as-Registry approach via a spike.
+
+## Deliverables
+
+### [Specify basic λAccount protocol](TBD: anoncomms-pm issue)
+
+**Owner**: Messaging Chat (primary), AnonComms Identity (review)
+
+**FURPS**:
+- U1. The basic identity protocol (address format, operation log, contact discovery flow) is published in a specification.
+
+**Checklist**:
+- [ ] Specs: link to specs and/or API definition
+
+### [Spike: LEZ-as-Registry feasibility](TBD: anoncomms-pm issue)
+
+**Owner**: Messaging Chat
+
+**FURPS**:
+- P1. A registry lookup of an identity's current state completes within a bounded time under typical network conditions.
+
+**Checklist**:
+- [ ] Docs: links to README.md or other docs
+
+### [Implement key-based identity](TBD: anoncomms-pm issue)
+
+**Owner**: Messaging Chat
+
+**FURPS**:
+- F1. An identity is bound to at least one cryptographic key whose private part is controlled by the holder.
+
+**Checklist**:
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or other docs

--- a/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
+++ b/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
@@ -39,6 +39,16 @@ and a working contact-discovery flow.
 - [ ] Dogfood: link to dogfooding session/artefact
 - [ ] Docs: links to README.md or other docs
 
+### [Investigate dedicated Identity Zone for registry](TBD: anoncomms-pm issue)
+
+**Owner**: Messaging Chat
+
+**FURPS**:
+- U7. The registry backend choice on the Logos Blockchain (LEZ program vs dedicated Identity Zone) is evaluated and documented.
+
+**Checklist**:
+- [ ] Docs: links to README.md or other docs
+- [ ] Specs: link to specs and/or API definition
 
 ### [Specify registry interface](TBD: anoncomms-pm issue)
 

--- a/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
+++ b/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
@@ -1,0 +1,51 @@
+# [Identity Track: Testnet v0.3](TBD: anoncomms-pm milestone)
+
+**Track:** [Identity Track](/anoncomms/roadmap/identity.md)
+
+**FURPS:** [Identity FURPS](/anoncomms/furps/identity.md)
+
+**Estimated date of completion**: in line with v0.3 freeze
+
+**Resources Required**:
+- 1 AnonComms researcher for review
+- Messaging Chat team ownership of libchat-side deliverables
+
+This milestone delivers the first λAccount V1 implementation:
+VLAD-compatible addresses,
+the append-only operation log of keys,
+and a working contact-discovery flow.
+
+## Deliverables
+
+### [Implement basic λAccount library](TBD: logos-messaging/pm issue)
+
+**Owner**: Messaging Chat
+
+**FURPS**:
+- F2. An identity has a stable, long-lived address that does not change when keys rotate or are revoked.
+- F3. An identity carries an append-only operation log of credential changes.
+- F4. An identity can be created without permission from any third party.
+- F5. An identity can hold one or more installation keys.
+- F6. A new installation can be added to an identity by an authorised current installation.
+- F7. An installation can be revoked by an authorised current installation.
+- F8. An identity is consumable by de-MLS to retrieve the key package for an active installation.
+- F10. An identity can be discovered by contacts via address share and registry lookup.
+- U3. The identity library is implemented in Rust.
+- U4. The identity library is available via C-bindings.
+- U5. The identity library is integrated into a working Logos Chat module deployed to Logos Core.
+
+**Checklist**:
+- [ ] Code: link to GitHub issues/PRs/Epic
+- [ ] Dogfood: link to dogfooding session/artefact
+- [ ] Docs: links to README.md or other docs
+
+
+### [Specify registry interface](TBD: anoncomms-pm issue)
+
+**Owner**: Messaging Chat
+
+**FURPS**:
+- U2. The registry interface (lookup, write authorisation) is published in a specification.
+
+**Checklist**:
+- [ ] Specs: link to specs and/or API definition

--- a/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
+++ b/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
@@ -22,14 +22,13 @@ and a working contact-discovery flow.
 **Owner**: Messaging Chat
 
 **FURPS**:
-- F2. An identity has a stable, long-lived address that does not change when keys rotate or are revoked.
-- F3. An identity carries an append-only operation log of credential changes.
-- F4. An identity can be created without permission from any third party.
-- F5. An identity can hold one or more installation keys.
-- F6. A new installation can be added to an identity by an authorised current installation.
-- F7. An installation can be revoked by an authorised current installation.
-- F8. An identity is consumable by de-MLS to retrieve the key package for an active installation.
-- F10. An identity can be discovered by contacts via address share and registry lookup.
+- F2. An account has a stable, long-lived address that does not change when keys rotate or are revoked.
+- F3. An account carries an append-only operation log of credential changes.
+- F4. An account can be created without permission from any third party.
+- F5. An account can hold one or more keys.
+- F6. A new key can be added to an account by the account holder.
+- F7. A key can be revoked by the account holder.
+- F8. Given an account address, anyone can query for the associated keys.
 - U3. The identity library is implemented in Rust.
 - U4. The identity library is available via C-bindings.
 - U5. The identity library is integrated into a working Logos Chat module deployed to Logos Core.

--- a/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
+++ b/content/anoncomms/roadmap/testnet_v0.3/identity_v0.3.md
@@ -26,9 +26,10 @@ and a working contact-discovery flow.
 - F3. An account carries an append-only operation log of credential changes.
 - F4. An account can be created without permission from any third party.
 - F5. An account can hold one or more keys.
-- F6. A new key can be added to an account by the account holder.
-- F7. A key can be revoked by the account holder.
+- F6. A new key can be added to an account.
+- F7. A key can be revoked from the account.
 - F8. Given an account address, anyone can query for the associated keys.
+- F9. Single-key compromise must not permit irreversible account takeover.
 - U3. The identity library is implemented in Rust.
 - U4. The identity library is available via C-bindings.
 - U5. The identity library is integrated into a working Logos Chat module deployed to Logos Core.


### PR DESCRIPTION
Introduces a minimal roadmap for Identity based on the work already proposed (and in-flight) by @jazzz and the Chat Team.

The aim is to have for mainnet:
- a simple accounts model with VLAD-like addresses mapping to an operation log of credential changes
- support for key addition and revocation (account holder only, for now)
- support for multiple devices