### PR TITLE
docs(messaging): rename milestone files to match titles

### DIFF
--- a/content/combined_roadmap.md
+++ b/content/combined_roadmap.md
@@ -116,15 +116,15 @@ gantt
     
     section Messaging - Launch Critical
     Create Chat SDK MVP                            :crit, active, msg1, 2025-06-24, 2025-12-31
-    click msg1 href "/messaging/roadmap/milestones/2025-create-chat-sdk-mvp"
+    click msg1 href "/messaging/roadmap/milestones/2026-chat-foundations"
     Extend Chat SDK with Group Conversations       :crit, msg2, 2025-12-18, 2026-06-30
     click msg2 href "/messaging/roadmap/milestones/2025-extend-chat-sdk-with-group-conversations"
     API access to P2P Reliability for Desktop      :active, msg3, 2025-07-03, 2025-08-31
-    click msg3 href "/messaging/roadmap/milestones/2025-api-access-to-p2p-reliability-for-desktop"
+    click msg3 href "/messaging/roadmap/milestones/2026-messaging-api-developer-preview"
     Package SDS in Reliable Channel API            :msg4, 2025-12-10, 2026-03-31
-    click msg4 href "/messaging/roadmap/milestones/2025-package-sds-in-reliable-channel-api"
+    click msg4 href "/messaging/roadmap/milestones/2026-reliable-channel-api-developer-preview"
     Enable easy C-Bindings for Desktop             :active, msg5, 2025-12-19, 2026-03-31
-    click msg5 href "/messaging/roadmap/milestones/2025-enable-easy-c-bindings-for-desktop"
+    click msg5 href "/messaging/roadmap/milestones/2026-initial-integration-to-logos-core"
     
     section Messaging - Launch Important
     Support Discovery Research & Libp2p QUIC       :msg6, 2025-12-03, 2026-06-30
@@ -136,7 +136,7 @@ gantt
     Messaging and Chat on Mobile                   :msg9, 2025-12-11, 2026-06-30
     click msg9 href "/messaging/roadmap/milestones/2025-messaging-chat-on-mobile"
     Complete Reliable Channel API                  :msg10, 2025-12-17, 2026-06-30
-    click msg10 href "/messaging/roadmap/milestones/2026-complete-reliable-channel-api"
+    click msg10 href "/messaging/roadmap/milestones/2026-reliable-channel-api-general-availability"
     Implement RLN Membership Management            :active, msg11, 2025-09-30, 2026-03-31
     click msg11 href "/messaging/roadmap/milestones/2025-implement-rln-membership-management"
     Add Support of RLN LSSA                        :msg12, 2026-01-01, 2026-09-30

--- a/content/messaging/roadmap/index.md
+++ b/content/messaging/roadmap/index.md
@@ -30,14 +30,14 @@ We use two release stages for developer-facing APIs and libraries:
 
 ### Testnet [v0.1](v01)
 
-- [x] [Messaging API — Developer Preview](2025-api-access-to-p2p-reliability-for-desktop.md)
-- [x] [Chat — Foundations](2025-create-chat-sdk-mvp.md)
-- [ ] [Initial Integration to Logos Core](2025-enable-easy-c-bindings-for-desktop.md)
+- [x] [Messaging API — Developer Preview](2026-messaging-api-developer-preview.md)
+- [x] [Chat — Foundations](2026-chat-foundations.md)
+- [ ] [Initial Integration to Logos Core](2026-initial-integration-to-logos-core.md)
 
 ### Testnet [v0.2](v02)
 
 - [ ] [Messaging API — General Availability](2026-messaging-api-general-availability)
-- [ ] [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+- [ ] [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 - [ ] [Chat — Group Conversations](2025-extend-chat-sdk-with-group-conversations)
 - [ ] [Logos Core Integration — Phase 2](2026-logos-core-integration-phase-2)
 - [ ] [QUIC Transport in Logos Delivery](2025-support-discovery-research-and-libp2p-quic)
@@ -45,7 +45,7 @@ We use two release stages for developer-facing APIs and libraries:
 
 ### Testnet [v0.3](v03)
 
-- [ ] [Reliable Channel API — General Availability](2026-complete-reliable-channel-api.md)
+- [ ] [Reliable Channel API — General Availability](2026-reliable-channel-api-general-availability.md)
 - [ ] [Chat — Developer Preview](2026-chat-developer-preview)
 - [ ] [RLN on Logos Blockchain](2026-add-support-for-rln-on-lee)
 
@@ -71,9 +71,9 @@ We use two release stages for developer-facing APIs and libraries:
 
 ## H2 2025
 
-- [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+- [Create Chat SDK MVP](2026-chat-foundations.md)
 - [Messaging API](2025-messaging-api.md)
-- [Enable easy C-Bindings for Desktop](2025-enable-easy-c-bindings-for-desktop.md)
+- [Enable easy C-Bindings for Desktop](2026-initial-integration-to-logos-core.md)
 - [Formalize and Expand Waku Web Apps](2025-formalize-and-expand-waku-web-apps.md)
 - [Harden RLN Testnet Deployment](2025-harden-rln-testnet-deployment.md)
 - [Improve DevEx: API, TWN, Metrics, Docs](2025-improve-devex.md)
@@ -95,9 +95,9 @@ We use two release stages for developer-facing APIs and libraries:
 
 - [Implement RLN Membership Management](2025-implement-rln-membership-management.md) — superseded by [RLN on Logos Blockchain](2026-add-support-for-rln-on-lee)
 - [Support Discovery Research and Libp2p QUIC](2025-support-discovery-research-and-libp2p-quic.md) — discovery now under AnonComms; QUIC moved to v0.2
-- [Enable easy C-Bindings for Desktop](2025-enable-easy-c-bindings-for-desktop.md) — absorbed into [Initial Integration to Logos Core](2025-enable-easy-c-bindings-for-desktop.md)
+- [Enable easy C-Bindings for Desktop](2026-initial-integration-to-logos-core.md) — absorbed into [Initial Integration to Logos Core](2026-initial-integration-to-logos-core.md)
 - [Enable easy C-Bindings for Mobile](2025-enable-easy-c-bindings-for-mobile.md) — absorbed into [Support Mobile Platforms](2026-support-mobile-platforms)
-- [Add Edge Mode to Messaging API](2025-add-edge-mode-to-messaging-api.md) — absorbed into [Messaging API — Developer Preview](2025-api-access-to-p2p-reliability-for-desktop)
+- [Add Edge Mode to Messaging API](2025-add-edge-mode-to-messaging-api.md) — absorbed into [Messaging API — Developer Preview](2026-messaging-api-developer-preview)
 - [Messaging and Chat on Mobile](2025-messaging-chat-on-mobile.md) — absorbed into [Support Mobile Platforms](2026-support-mobile-platforms)
 - [Add peer discovery to mixnet and support browser](2025-add-peer-discovery-to-mixnet-and-support-browser.md)
 - [Debugging Tools](2025-debugging-tools.md)

--- a/content/messaging/roadmap/milestones/2025-extend-chat-sdk-with-group-conversations.md
+++ b/content/messaging/roadmap/milestones/2025-extend-chat-sdk-with-group-conversations.md
@@ -28,7 +28,7 @@ Group chat features will be limited at this stage and extended with further mile
 
 | Type/Level      | Risk                             | (Accept, Own, Mitigation)                                                                                                                                              |
 | --------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Schedule/Medium | Milestone dependency             | This milestone depends on [Chat — Foundations](2025-create-chat-sdk-mvp.md). Delays there translate into delays here.                                                        |
+| Schedule/Medium | Milestone dependency             | This milestone depends on [Chat — Foundations](2026-chat-foundations.md). Delays there translate into delays here.                                                        |
 | Technical/Low   | Group chat bugs                  | Group chat is prone to bugs even when using existing encryption protocols. Extra time allocated to testing and debugging.                                              |
 | Technical/High  | SDS and de-MLS ordering conflict | SDS works backward in the dependency tree, but de-MLS requires forward construction from checkpoints. Specific deliverable scheduled to design and define integration. |
 | Technical/High  | Nim shim removal feasibility     | Removing the Nim layer is only possible if Logos Chat remains fully synchronous. If async is required (e.g. for data storage), the removal may not be feasible.        |

--- a/content/messaging/roadmap/milestones/2026-chat-foundations.md
+++ b/content/messaging/roadmap/milestones/2026-chat-foundations.md
@@ -6,9 +6,6 @@ date: 2025-06-24
 github: 'https://github.com/logos-messaging/pm/issues/407'
 ---
 
-> [!NOTE] This file will be renamed to `2026-chat-foundations`
-
-
 **Resources Required for 2026H1**:
 - 2 Chat Researchers
 - 1 Delivery Dev for 1 month (C-bindings)

--- a/content/messaging/roadmap/milestones/2026-initial-integration-to-logos-core.md
+++ b/content/messaging/roadmap/milestones/2026-initial-integration-to-logos-core.md
@@ -6,9 +6,6 @@ date: 19-01-2026
 github: https://github.com/logos-messaging/pm/issues/398
 ---
 
-> [!NOTE] This file will be renamed to `2026-logos-core-initial-integration`
-
-
 **Resources Required for 2026H1**:
 - 2 devs for 1 month from Delivery Team
 - 1 dev for 1 month from Chat Team

--- a/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-2.md
+++ b/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-2.md
@@ -59,7 +59,7 @@ The Chat module API is extended to expose group chat functionality (create group
 
 **Owner**: Delivery Team
 
-When the [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md) is ready, the Delivery Logos Core module is updated to expose it alongside the Messaging API. Chat module switches to using Reliable Channel API for message delivery.
+When the [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md) is ready, the Delivery Logos Core module is updated to expose it alongside the Messaging API. Chat module switches to using Reliable Channel API for message delivery.
 
 ### POC: Delivery module uses Discovery module for peer discovery
 

--- a/content/messaging/roadmap/milestones/2026-messaging-api-developer-preview.md
+++ b/content/messaging/roadmap/milestones/2026-messaging-api-developer-preview.md
@@ -6,9 +6,6 @@ date: 2025-07-03
 github: 'https://github.com/logos-messaging/pm/issues/395'
 ---
 
-> [!NOTE] This file will be renamed to `2026-messaging-api-developer-preview`
-
-
 **Resources Required for 2026H1**:
 - 3 Nim engineers
 

--- a/content/messaging/roadmap/milestones/2026-reliable-channel-api-developer-preview.md
+++ b/content/messaging/roadmap/milestones/2026-reliable-channel-api-developer-preview.md
@@ -6,21 +6,18 @@ date: 2025-12-10
 github: https://github.com/logos-messaging/pm/issues/405
 ---
 
-> [!NOTE] This file will be renamed to `2026-reliable-channel-api-developer-preview`
-
-
 **Resources Required for 2026H1**:
 - 2 Delivery engineers
 - 1 Chat engineer for integration
 
-The [Chat — Foundations](2025-create-chat-sdk-mvp.md) milestone does not include the [Scalable Data Sync](https://github.com/vacp2p/rfc-index/blob/main/vac/raw/sds.md) protocol. This milestone delivers dedicated work to fully leverage SDS to:
+The [Chat — Foundations](2026-chat-foundations.md) milestone does not include the [Scalable Data Sync](https://github.com/vacp2p/rfc-index/blob/main/vac/raw/sds.md) protocol. This milestone delivers dedicated work to fully leverage SDS to:
 - Identify and retrieve missed messages
 - Track, acknowledge, and resend unacknowledged messages
 
 The [Reliable Channel API](https://github.com/logos-messaging/specs/pull/89) delivers a simple API that enables those features, as well as:
 - SDS-Repair, an extension to SDS that reduces reliance on Store services and improves receiver anonymity from the original SDS protocol.
 
-This milestone focuses on forming the API and delivering a pre-configured SDS experience. Segmentation and rate limit manager will be delivered in the [General Availability](2026-complete-reliable-channel-api.md) milestone.
+This milestone focuses on forming the API and delivering a pre-configured SDS experience. Segmentation and rate limit manager will be delivered in the [General Availability](2026-reliable-channel-api-general-availability.md) milestone.
 
 ## FURPS
 

--- a/content/messaging/roadmap/milestones/2026-reliable-channel-api-general-availability.md
+++ b/content/messaging/roadmap/milestones/2026-reliable-channel-api-general-availability.md
@@ -6,14 +6,11 @@ date: 2025-12-17
 github: https://github.com/logos-messaging/pm/issues/402
 ---
 
-> [!NOTE] This file will be renamed to `2026-reliable-channel-api-general-availability`
-
-
 **Resources Required for 2026H2**:
 - 2 Delivery engineers
 - 1 Chat engineer
 
-The [Developer Preview](2025-package-sds-in-reliable-channel-api.md) delivers the core SDS experience. This milestone completes the [Reliable Channel API](https://github.com/logos-messaging/specs/pull/89) by adding:
+The [Developer Preview](2026-reliable-channel-api-developer-preview.md) delivers the core SDS experience. This milestone completes the [Reliable Channel API](https://github.com/logos-messaging/specs/pull/89) by adding:
 - Message segmentation for large payloads
 - Rate limit management (in preparation for future RLN integration)
 

--- a/content/messaging/roadmap/milestones/2026-status-logos-chat-integration.md
+++ b/content/messaging/roadmap/milestones/2026-status-logos-chat-integration.md
@@ -31,7 +31,7 @@ Status switches from its current chat protocol implementation to Logos Chat, con
 
 ## Related milestones
 
-- [Chat — Foundations](2025-create-chat-sdk-mvp.md) (v0.1) — 1:1 chats
+- [Chat — Foundations](2026-chat-foundations.md) (v0.1) — 1:1 chats
 - [Chat — Group Conversations](2025-extend-chat-sdk-with-group-conversations) (v0.2) — group chats via de-MLS
 - [Chat — Developer Preview](2026-chat-developer-preview) (v0.3) — first external release
 - [Logos Core Integration — Phase 2](2026-logos-core-integration-phase-2) — Chat ↔ Delivery through Logos Core

--- a/content/messaging/templates/weekly-update-template.md
+++ b/content/messaging/templates/weekly-update-template.md
@@ -37,7 +37,7 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
   - achieved:
@@ -49,7 +49,7 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-## [Reliable Channel API — General Availability](2026-complete-reliable-channel-api.md)
+## [Reliable Channel API — General Availability](2026-reliable-channel-api-general-availability.md)
 
 - [[Deliverable] Create Segmentation Library](https://github.com/logos-messaging/pm/issues/318)
   - achieved:
@@ -175,7 +175,7 @@ title: 2026-MM-DD Messaging Weekly
 
 # Logos Core
 
-## [Initial integration into Logos Core](2025-enable-easy-c-bindings-for-desktop.md)
+## [Initial integration into Logos Core](2026-initial-integration-to-logos-core.md)
 
 - [[Deliverable] Deploy required fleets for Testnet](https://github.com/logos-messaging/pm/issues/386)
   - achieved:

--- a/content/messaging/updates/2025-06-23.md
+++ b/content/messaging/updates/2025-06-23.md
@@ -69,7 +69,7 @@ date: 2025-06-23
     - [js-waku] [improve peer codec matching for Filter](https://github.com/waku-org/js-waku/issues/2418)
     - [js-waku] [implement Messaging Storage API first iteration](https://github.com/waku-org/js-waku/issues/2381)
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-07-07.md
+++ b/content/messaging/updates/2025-07-07.md
@@ -65,7 +65,7 @@ date: 2025-07-07
     - [js-waku] [connection dialing improvements](https://github.com/waku-org/js-waku/issues/2236)
     - [js-waku] [connection management limitations](https://github.com/waku-org/js-waku/issues/2168)
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-07-14.md
+++ b/content/messaging/updates/2025-07-14.md
@@ -81,7 +81,7 @@ date: 2025-07-14
     - [js-waku] [measure and investigate cold/warm bootstrap after recent improvements](https://github.com/waku-org/js-waku/issues/2477)
     - [js-waku] [introduce routing info concept](https://github.com/waku-org/js-waku/issues/2484)
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved: [chat] [Proposed Inbox spec](https://github.com/waku-org/specs/pull/72)

--- a/content/messaging/updates/2025-07-21.md
+++ b/content/messaging/updates/2025-07-21.md
@@ -73,7 +73,7 @@ date: 2025-07-21
     - [js-waku] [improve peer exchange by enabling continuous queries to connected peers](https://github.com/waku-org/js-waku/issues/1860)
     - [js-waku] [introduce routing info concept](https://github.com/waku-org/js-waku/issues/2484)
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [Create Segmentation Library](https://github.com/waku-org/pm/issues/318)
   - achieved: [chat] [add data storage for the segmentation](https://github.com/waku-org/nim-chat-sdk/pull/1)

--- a/content/messaging/updates/2025-07-28.md
+++ b/content/messaging/updates/2025-07-28.md
@@ -66,7 +66,7 @@ date: 2025-07-28
 - [[Deliverable] Integrate libp2p mix into lightpush](https://github.com/waku-org/pm/issues/291)
   - achieved: [research] chat2 application that publishes using mix is ready and tested with a local mix network
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved: [Waku Integration](https://github.com/waku-org/nim-chat-poc/pull/4) in Nim Chat POC.

--- a/content/messaging/updates/2025-08-04.md
+++ b/content/messaging/updates/2025-08-04.md
@@ -56,12 +56,12 @@ date: 2025-08-04
   - achieved: [research] working on nwaku PRs and chat2 app simulation scripts.
   - next: [research] reviewing of mix protocol PRs
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [Create Rate Limit Manager](https://github.com/waku-org/pm/issues/319)
   - achieved: [chat] [rate limit persist queued messages](https://github.com/waku-org/nim-chat-sdk/pull/6)
 
-## [Upgrade Nim Usage](2025-enable-easy-c-bindings-for-desktop.md)
+## [Upgrade Nim Usage](2026-initial-integration-to-logos-core.md)
 
 - [Create nim-ffi](https://github.com/waku-org/pm/issues/332)
   - next: [nwaku] Create fundamental nim-ffi repository that extracts the current libwaku logic.

--- a/content/messaging/updates/2025-08-11.md
+++ b/content/messaging/updates/2025-08-11.md
@@ -52,7 +52,7 @@ date: 2025-08-11
   - achieved: [research] presented chat2 app with integrated mix at townhall
   - blockers: [research] waiting for reply-path SURB implementation in nim-libp2p
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [Create Rate Limit Manager](https://github.com/waku-org/pm/issues/319)
   - achieved: [chat] addressing comments in PRs [https://github.com/waku-org/nim-chat-sdk/pull/6](1) [https://github.com/waku-org/nim-chat-sdk/pull/5](2)

--- a/content/messaging/updates/2025-08-18.md
+++ b/content/messaging/updates/2025-08-18.md
@@ -47,7 +47,7 @@ date: 2025-08-18
   - achieved: [research] Analyzed mix for browsers from implementation perspective (if it has to be implemented in js-waku)
   - blockers: [research] Still waiting for SURB implementation from p2p team
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [Create Segmentation Library](https://github.com/waku-org/pm/issues/318)
   - achieved:
@@ -69,7 +69,7 @@ date: 2025-08-18
     - [chat] callsign/nicknames
     - [chat] localstorage -> indexedDB
 
-## [Upgrade Nim Usage](2025-enable-easy-c-bindings-for-desktop.md)
+## [Upgrade Nim Usage](2026-initial-integration-to-logos-core.md)
 
 - [Create nim-ffi](https://github.com/waku-org/pm/issues/332)
   - next:

--- a/content/messaging/updates/2025-09-08.md
+++ b/content/messaging/updates/2025-09-08.md
@@ -45,7 +45,7 @@ date: 2025-09-08
   - achieved: [research] [Post](https://forum.vac.dev/t/mix-implementation-in-javascript-and-js-waku/563) on how mix can be implemented in js and integrated into js-waku
   - blockers: [research] Still waiting on p2p team to get back on SURB implementation.
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-09-15.md
+++ b/content/messaging/updates/2025-09-15.md
@@ -54,7 +54,7 @@ date: 2025-09-15
       - [research] Merged [mix-poc PR](https://github.com/waku-org/nwaku/pull/3284) after SURB implementation to master
       - [research] Wrote a [blog post](https://forum.vac.dev/t/mix-implementation-in-javascript-and-js-waku/563) about Mix implementation in javascript
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-09-22.md
+++ b/content/messaging/updates/2025-09-22.md
@@ -46,7 +46,7 @@ date: 2025-09-22
   - achieved: [research] deployed mix nodes on the Waku Network, continued dogfooding
   - next: [research] address issue of ENR size out of bands when deploying mix to fleets
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-10-20.md
+++ b/content/messaging/updates/2025-10-20.md
@@ -35,7 +35,7 @@ date: 2025-10-20
   - achieved: [research] updated rendezvous in nim-libp2p to support generics https://github.com/vacp2p/nim-libp2p/pull/1719
   - next: [research] waku rendezvous changes for mix and testing https://github.com/waku-org/nwaku/pull/3617
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved: [chat] [draft implementation of nim noise KN pattern](https://github.com/threeproto/nim-noise)
@@ -44,7 +44,7 @@ date: 2025-10-20
 - [[Deliverable] Create Segmentation Library](https://github.com/waku-org/pm/issues/318)
   - achieved: [chat] [segmentation specs](https://github.com/waku-org/specs/pull/91)
 
-## [Upgrade Nim Usage](2025-enable-easy-c-bindings-for-desktop.md)
+## [Upgrade Nim Usage](2026-initial-integration-to-logos-core.md)
 
 - [Create nim-ffi](https://github.com/waku-org/pm/issues/332)
   - achieved: [nwaku] [New protobuf approach](https://github.com/NagyZoltanPeter/nim-binding-demo)

--- a/content/messaging/updates/2025-10-27.md
+++ b/content/messaging/updates/2025-10-27.md
@@ -61,7 +61,7 @@ date: 2025-10-27
   - achieved: [research] enabled mix in waku.test fleet and dogfooded with chat2mix locally; milestone completed
 
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:
@@ -85,7 +85,7 @@ date: 2025-10-27
     - [chat] Qaku redesign: qaku.app
     - [chat] Qaku Desktop - qaku + codex bundled in a native desktop app
 
-## [Upgrade Nim Usage](2025-enable-easy-c-bindings-for-desktop.md)
+## [Upgrade Nim Usage](2026-initial-integration-to-logos-core.md)
 
 - [Create nim-ffi](https://github.com/waku-org/pm/issues/332)
   - next:

--- a/content/messaging/updates/2025-11-03.md
+++ b/content/messaging/updates/2025-11-03.md
@@ -25,7 +25,7 @@ date: 2025-11-03
 - [[Deliverable] Local Web Dev Harness](https://github.com/waku-org/pm/issues/359)
   - achieved: [js-waku] [document local development environment](https://github.com/waku-org/js-waku/issues/2709)
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved: [chat] [noise examples](https://github.com/waku-org/nim-chat-sdk/pull/13)

--- a/content/messaging/updates/2025-11-10.md
+++ b/content/messaging/updates/2025-11-10.md
@@ -59,7 +59,7 @@ Key discussion areas included:
   - achieved: Discussion on WebRTC integration for low latency meshes in browser environments
   - next: Continue WebRTC signaling implementation incorporating offsite architectural feedback
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-11-24.md
+++ b/content/messaging/updates/2025-11-24.md
@@ -42,7 +42,7 @@ date: 2025-11-24
         - Extend P2pReliability feature to stand as managing send operations in wider terms.
           - Handle cases where no Store service is available and/or no P2PReliability is set.
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-12-01.md
+++ b/content/messaging/updates/2025-12-01.md
@@ -47,7 +47,7 @@ date: 2025-12-01
         - Refactored the P2PReliability feature into a send service with fallback options.
             - Some fixes and tests are left before completion.
 
-## [Create Chat SDK MVP](milestones/messaging/open/2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](milestones/messaging/open/2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-12-08.md
+++ b/content/messaging/updates/2025-12-08.md
@@ -41,7 +41,7 @@ date: 2025-12-08
     - [nwaku] [pin rln dependencies to specific version](https://github.com/logos-messaging/nwaku/pull/3649)
     - [nwaku] [Review gas fee calculation and Anvil testnet config](https://github.com/logos-messaging/nwaku/issues/3643)
 
-## [Create Chat SDK MVP](milestones/messaging/open/2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](milestones/messaging/open/2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2025-12-15.md
+++ b/content/messaging/updates/2025-12-15.md
@@ -9,7 +9,7 @@ date: 2025-12-15
 
 - nwaku: Extract library ffi code from logos-messaging-nim to nim-ffi repository
 
-## [Create Chat SDK MVP](milestones/messaging/open/2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](milestones/messaging/open/2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved: Reworked Inbox PrivateV1 handoff: https://github.com/logos-messaging/nim-chat-poc/pull/38

--- a/content/messaging/updates/2025-12-22.md
+++ b/content/messaging/updates/2025-12-22.md
@@ -23,7 +23,7 @@ date: 2025-12-22
     - [nim] [Implement simple `send` API](https://github.com/logos-messaging/logos-messaging-nim/pull/3669)
     - [nim] [Implement Health API](https://github.com/logos-messaging/nwaku/issues/3646)
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:
@@ -35,7 +35,7 @@ date: 2025-12-22
 - [[Deliverable] Chat SDK Bindings](https://github.com/waku-org/pm/issues/317)
   - achieved: [logos] [c-bindings pr](https://github.com/logos-messaging/nim-chat-poc/pull/47)
 
-## [Upgrade Nim Usage](2025-enable-easy-c-bindings-for-desktop.md)
+## [Upgrade Nim Usage](2026-initial-integration-to-logos-core.md)
 
 - [Create nim-ffi](https://github.com/waku-org/pm/issues/332)
   - achieved: [nim] [Use nim-ffi dependency in logos-messaging-nim](https://github.com/logos-messaging/logos-messaging-nim/issues/3655)

--- a/content/messaging/updates/2026-01-12.md
+++ b/content/messaging/updates/2026-01-12.md
@@ -12,7 +12,7 @@ date: 2026-01-12
   - Automatic certificate renewal in logos-messaging-nim-compose.
   - Better understanding of Anvil gas price calculation.
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-01-19.md
+++ b/content/messaging/updates/2026-01-19.md
@@ -9,7 +9,7 @@ date: 2026-01-19
 
 - Logos Integrations: [logos-chatsdk-module](https://github.com/logos-co/logos-chatsdk-module) 
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-01-26.md
+++ b/content/messaging/updates/2026-01-26.md
@@ -5,7 +5,7 @@ tags:
 date: 2026-01-26
 ---
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-02-02.md
+++ b/content/messaging/updates/2026-02-02.md
@@ -13,7 +13,7 @@ date: 2026-02-02
 - Chat: 
   - Implemented UI for chatsdk module https://github.com/logos-co/logos-chatsdk-ui
 
-## [Create Chat SDK MVP](/messaging/milestones/open/2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](/messaging/milestones/open/2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-02-09.md
+++ b/content/messaging/updates/2026-02-09.md
@@ -13,7 +13,7 @@ date: 2026-02-09
 - Logos Integrations:
 - Status:
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-02-16.md
+++ b/content/messaging/updates/2026-02-16.md
@@ -11,7 +11,7 @@ date: 2026-02-16
 - Logos Delivery:
   - Implement health API
   - Completed nix + nimble integration in nim-sds
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-02-23.md
+++ b/content/messaging/updates/2026-02-23.md
@@ -10,7 +10,7 @@ date: 2026-02-23
 
 - Delivery:
   - Create basic logos deliver module structure
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-03-02.md
+++ b/content/messaging/updates/2026-03-02.md
@@ -13,7 +13,7 @@ date: 2026-03-02
 	- Logos Core module API docs
 	- Switched modules to use `logos.dev` fleet
 
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-03-23.md
+++ b/content/messaging/updates/2026-03-23.md
@@ -10,7 +10,7 @@ date: 2026-03-23
 
 - Logos Delivery:
   - Released v0.37.2
-## [Create Chat SDK MVP](2025-create-chat-sdk-mvp.md)
+## [Create Chat SDK MVP](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/waku-org/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-03-30.md
+++ b/content/messaging/updates/2026-03-30.md
@@ -13,14 +13,14 @@ date: 2026-03-30
 
 # Logos Delivery
 
-## [Messaging API — Developer Preview](2025-api-access-to-p2p-reliability-for-desktop.md)
+## [Messaging API — Developer Preview](2026-messaging-api-developer-preview.md)
 
 - [[Deliverable] Introduce Messaging API in Logos Delivery](https://github.com/logos-messaging/pm/issues/305)
   - achieved:
     - [implement subscribe and receive API](https://github.com/logos-messaging/logos-delivery/issues/3710)
 
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [Deliverable] Deliver Reliable Channel API
   - next:
@@ -50,7 +50,7 @@ date: 2026-03-30
 
 # Logos Chat
 
-## [Chat — Foundations](2025-create-chat-sdk-mvp.md)
+## [Chat — Foundations](2026-chat-foundations.md)
 
 - [[Deliverable] Logos Chat Library](https://github.com/logos-messaging/pm/issues/316)
   - achieved:
@@ -60,7 +60,7 @@ date: 2026-03-30
 
 # Logos Core
 
-## [Initial Integration to Logos Core](2025-enable-easy-c-bindings-for-desktop.md)
+## [Initial Integration to Logos Core](2026-initial-integration-to-logos-core.md)
 
 - [[Deliverable] Implement a Delivery module for Logos Core](https://github.com/logos-messaging/pm/issues/374)
   - next:

--- a/content/messaging/updates/2026-04-06.md
+++ b/content/messaging/updates/2026-04-06.md
@@ -16,7 +16,7 @@ date: 2026-04-06
 
 # Logos Delivery
 
-## [Messaging API — Developer Preview](2025-api-access-to-p2p-reliability-for-desktop.md)
+## [Messaging API — Developer Preview](2026-messaging-api-developer-preview.md)
 
 - [[Deliverable] Introduce Messaging API in Logos Delivery](https://github.com/logos-messaging/pm/issues/305)
   - achieved:
@@ -28,7 +28,7 @@ date: 2026-04-06
   - achieved:
     - [Prefer reusing service peers across shards in edge filter reconciliation](https://github.com/logos-messaging/logos-delivery/pull/3789)
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Reliable Channel API — Developer Preview](https://github.com/logos-messaging/pm/issues/405)
   - next:
@@ -58,7 +58,7 @@ date: 2026-04-06
 
 # Logos Chat
 
-## [Chat — Foundations](2025-create-chat-sdk-mvp.md)
+## [Chat — Foundations](2026-chat-foundations.md)
 
 - [[Deliverable] Logos Chat Library](https://github.com/logos-messaging/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-04-13.md
+++ b/content/messaging/updates/2026-04-13.md
@@ -14,7 +14,7 @@ title: 2026-04-13 Messaging Weekly
 
 # Logos Delivery
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
   - next:
@@ -58,7 +58,7 @@ title: 2026-04-13 Messaging Weekly
 
 # Logos Core
 
-## [Initial Integration to Logos Core](2025-enable-easy-c-bindings-for-desktop.md)
+## [Initial Integration to Logos Core](2026-initial-integration-to-logos-core.md)
 
 - [[Deliverable] Deploy required fleets for Testnet](https://github.com/logos-messaging/pm/issues/386)
   - next:

--- a/content/messaging/updates/2026-04-20.md
+++ b/content/messaging/updates/2026-04-20.md
@@ -12,7 +12,7 @@ title: 2026-04-20 Messaging Weekly
 
 # Logos Delivery
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
   - next:
@@ -47,7 +47,7 @@ title: 2026-04-20 Messaging Weekly
 
 # Logos Chat
 
-## [Chat — Foundations](2025-create-chat-sdk-mvp.md)
+## [Chat — Foundations](2026-chat-foundations.md)
 
 - [[Deliverable] Chat SDK Developer Preview](https://github.com/logos-messaging/pm/issues/316)
   - achieved:

--- a/content/messaging/updates/2026-04-27.md
+++ b/content/messaging/updates/2026-04-27.md
@@ -7,7 +7,7 @@ title: 2026-04-27 Messaging Weekly
 
 # Logos Delivery
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
   - next:
@@ -50,7 +50,7 @@ title: 2026-04-27 Messaging Weekly
 
 # Logos Core
 
-## [Initial integration into Logos Core](2025-enable-easy-c-bindings-for-desktop.md)
+## [Initial integration into Logos Core](2026-initial-integration-to-logos-core.md)
 
 - [[Deliverable] Deploy required fleets for Testnet](https://github.com/logos-messaging/pm/issues/386)
   - achieved:

--- a/content/messaging/updates/2026-05-04.md
+++ b/content/messaging/updates/2026-05-04.md
@@ -12,7 +12,7 @@ title: 2026-05-04 Messaging Weekly
 
 # Logos Delivery
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
   - achieved:

--- a/content/messaging/updates/2026-05-11.md
+++ b/content/messaging/updates/2026-05-11.md
@@ -7,7 +7,7 @@ title: 2026-05-11 Messaging Weekly
 
 # Logos Delivery
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
   - achieved:

--- a/content/messaging/updates/2026-05-18.md
+++ b/content/messaging/updates/2026-05-18.md
@@ -13,7 +13,7 @@ title: 2026-05-18 Messaging Weekly
   - next:
     - [Lift Messaging API out of Waku into its own layer](https://github.com/logos-messaging/logos-delivery/issues/3865)
 
-## [Reliable Channel API — Developer Preview](2025-package-sds-in-reliable-channel-api.md)
+## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 
 - [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
   - achieved:

--- a/content/testnets/v02.md
+++ b/content/testnets/v02.md
@@ -12,7 +12,7 @@ tags: testnet
 * Capability Discovery module (alpha version, not used by other Logos modules yet)
 * Chat module uses Delivery module
 * Chat App shows [[2025-extend-chat-sdk-with-group-conversations|groups chats]] (using [[deliver_de-mls_api|de-MLS]] if ready, fallback to Sender Keys)
-* Delivery module exposes full [[2025-api-access-to-p2p-reliability-for-desktop|Messaging API]] (init, health, send, subscribe) and [[2025-package-sds-in-reliable-channel-api|Reliable Channel API]]
+* Delivery module exposes full [[2026-messaging-api-developer-preview|Messaging API]] (init, health, send, subscribe) and [[2026-reliable-channel-api-developer-preview|Reliable Channel API]]
 * LEZ module (indexer, gateway)
 * RLN membership  module (early PoC)
 * improved module documentation


### PR DESCRIPTION
Renames 5 milestone files that were marked with a `[!NOTE] This file will be renamed` note so the filename follows the milestone `title:`. Uses `git mv` to preserve history; the note lines are removed.

| Old | New |
|---|---|
| `2025-api-access-to-p2p-reliability-for-desktop` | `2026-messaging-api-developer-preview` |
| `2025-package-sds-in-reliable-channel-api` | `2026-reliable-channel-api-developer-preview` |
| `2025-enable-easy-c-bindings-for-desktop` | `2026-initial-integration-to-logos-core` |
| `2026-complete-reliable-channel-api` | `2026-reliable-channel-api-general-availability` |
| `2025-create-chat-sdk-mvp` | `2026-chat-foundations` |

All references updated across the roadmap index, milestone cross-links, weekly updates, testnet pages and the generated `combined_roadmap.md`.

**Not renamed (reported for follow-up):** other active milestones whose filename doesn't match the title — `2025-extend-chat-sdk-with-group-conversations` ("Chat — Group Conversations"), `2026-add-support-for-rln-on-lee` ("RLN on Logos Blockchain"), `2025-support-discovery-research-and-libp2p-quic` ("QUIC Transport in Logos Delivery", also under Closed Milestones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)