### PR TITLE
docs(storage): add RLN improvements to roadmap

### DIFF
--- a/content/storage/roadmap/tracks/v0.2-privacy-preserving-filesharing.md
+++ b/content/storage/roadmap/tracks/v0.2-privacy-preserving-filesharing.md
@@ -27,3 +27,4 @@ For v0.2, we intend to deliver a first draft spec.
 Collaboration with Anonymous Comms in improving the Mix network implementation.
 
 * [LIONESS spec](https://github.com/logos-storage/logos-storage-pm/issues/14): LIONESS will replace the AES-CTR implementation used in Mix payloads.
+* [RLN Improvements](https://github.com/logos-storage/logos-storage-pm/issues/21): RLN performance is a key limitator to Mix throughput and latency. We are delivering improvements to RLN which directly improve performance, allowing Mix to process more traffic faster with the same hardware.


### PR DESCRIPTION
Minor amendment to include RLN improvements to our roadmap. Those are now tracked as a deliverable on our end as well: https://github.com/logos-storage/logos-storage-pm/issues/21