### PR TITLE
blockchain weekly 2026-06-01

### DIFF
--- a/content/blockchain/updates/2026-06-01.md
+++ b/content/blockchain/updates/2026-06-01.md
@@ -1,0 +1,93 @@
+---
+title: 2026-06-01 Logos Blockchain weekly
+tags:
+  - nomos-updates
+date: 2026-06-01
+lastmod: 2026-06-01
+draft: false
+description: Weekly update of Logos Blockchain
+---
+
+# Logos Blockchain Weekly Update - 2026-06-01
+
+## `blockchain:highlights`
+
+- Sequencer-side Bridge Deposit flow merged on Logos Execution Zone (indexer side still to come) [logos-execution-zone#493](https://github.com/logos-blockchain/logos-execution-zone/pull/493)
+- Logos Blockchain Circuits: witness binaries dropped — circuits now consumed as Rust crates; prover binaries still to be removed
+- Nimbos Mantle ledger merged: makes use of persistent datastructures to support efficient state sharing between forks [nimbos#46](https://github.com/logos-co/nimbos/pull/46)
+
+## `blockchain:bedrock:research`
+
+- `blockchain:bedrock:research:total-stake-inference`
+  - "Modelling of Network Delays" document published: derives broadcast latency log(N)/α on a random regular graph network with linkdelay d+Exp(λ); simulation agreement for connectivity C≥8 [doc](https://www.notion.so/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0)
+
+- `blockchain:bedrock:research:cryptarchia`
+  - Checkpoint-based Fast Bootstrapping RFC: "Cryptarchia Protocol 1.0.2" subpage created with full revision details [subpage](https://www.notion.so/nomos-tech/1-0-2-Cryptarchia-Protocol-372261aa09df80d89da6e03b8f76a67b)
+
+- `blockchain:bedrock:research:native-zones`
+  - "Enable PoS Participation for Channels" RFC draft ready for review [RFC](https://www.notion.so/nomos-tech/RFC-Enable-PoS-Participation-for-Channels-36c261aa09df80a29c89c5b5463b357a)
+
+## `blockchain:bedrock:eng`
+
+- `blockchain:bedrock:eng:blend`
+  - Session removal landed across the stack: core components [logos-blockchain#2798](https://github.com/logos-blockchain/logos-blockchain/pull/2798), proxy service [#2800](https://github.com/logos-blockchain/logos-blockchain/pull/2800), edge service [#2804](https://github.com/logos-blockchain/logos-blockchain/pull/2804), core service [#2826](https://github.com/logos-blockchain/logos-blockchain/pull/2826), and safety-buffer + sessions removed from deployment settings [#2827](https://github.com/logos-blockchain/logos-blockchain/pull/2827)
+  - Overwatch Rust toolchain bumped to 1.96 (in-review) [Overwatch#135](https://github.com/logos-co/Overwatch/pull/135); consumer-side bump (in-review) [#2828](https://github.com/logos-blockchain/logos-blockchain/pull/2828)
+
+- `blockchain:bedrock:eng:mantle`
+  - Block-root calculation fix [logos-blockchain#2797](https://github.com/logos-blockchain/logos-blockchain/pull/2797)
+  - `bounded_vec` added to ledger tx builder inputs and outputs [#2791](https://github.com/logos-blockchain/logos-blockchain/pull/2791)
+  - PoQ tests aligned with the session-removal RFC (in-review) [#2802](https://github.com/logos-blockchain/logos-blockchain/pull/2802)
+
+- `blockchain:bedrock:eng:mempool`
+  - Mempool TxTracker implementation complete: tracks transactions across forks and serves leader sorted-by-tip txs (enables filler blocks and reduces inscription inclusion load from zones) (in-review) [logos-blockchain#2746](https://github.com/logos-blockchain/logos-blockchain/pull/2746)
+
+- `blockchain:bedrock:eng:decentralized-sequencing`
+  - Turn-to-write event for round-robin sequencers [logos-blockchain#2808](https://github.com/logos-blockchain/logos-blockchain/pull/2808)
+  - Sequencer timing endpoint exposed on node API (in-review) [#2816](https://github.com/logos-blockchain/logos-blockchain/pull/2816)
+
+- `blockchain:bedrock:eng:testing`
+  - Concurrent cucumber option added for parallel scenario runs [logos-blockchain#2803](https://github.com/logos-blockchain/logos-blockchain/pull/2803)
+  - Zone setup made explicit in e2e (in-review) [#2792](https://github.com/logos-blockchain/logos-blockchain/pull/2792)
+  - Mempool e2e coverage added [#2799](https://github.com/logos-blockchain/logos-blockchain/pull/2799)
+  - Testing HTTP API removed in favour of testing-framework signals [#2817](https://github.com/logos-blockchain/logos-blockchain/pull/2817)
+  - E2e test artifact handling improvements (in-review) [#2819](https://github.com/logos-blockchain/logos-blockchain/pull/2819)
+
+- `blockchain:bedrock:eng:node`
+  - Block write acknowledgement in storage (in-review) [logos-blockchain#2812](https://github.com/logos-blockchain/logos-blockchain/pull/2812)
+  - Block apply gated on storage success (in-review) [#2813](https://github.com/logos-blockchain/logos-blockchain/pull/2813)
+  - More crates migrated to the log targets crate [#2824](https://github.com/logos-blockchain/logos-blockchain/pull/2824)
+
+- `blockchain:bedrock:eng:circuits`
+  - Progress towards consuming circuits as Rust crates instead of external binaries: GMP consistency [logos-blockchain-circuits#31](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/31), documentation [#32](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/32), prebuilt-as-default behavior [#35](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/35), hardcoded test inputs fixed [#36](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/36), session fix [#34](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/34), expose missing files [#37](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/37), env-var unification [#38](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/38), rapidsnark crate abstracted [#39](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/39), CI caching fix [#40](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/40), Windows extension fix [#42](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/42)
+  - Circuit benchmarks merged on the node side [logos-blockchain#2679](https://github.com/logos-blockchain/logos-blockchain/pull/2679)
+  - Old circuits purged from logos-blockchain [#2829](https://github.com/logos-blockchain/logos-blockchain/pull/2829)
+
+## `blockchain:logos-execution-zone`
+
+- `blockchain:logos-execution-zone:accounts`
+  - Public and private transaction flows unified [logos-execution-zone#484](https://github.com/logos-blockchain/logos-execution-zone/pull/484)
+  - LEE/LEZ rename underway: NSSA → LEE rename across repo (in-review) [#499](https://github.com/logos-blockchain/logos-execution-zone/pull/499); lez-related crates moved into a new `lez/` folder (in-review) [#503](https://github.com/logos-blockchain/logos-execution-zone/pull/503)
+  - PQ Kyber-768 encryption specs added to the encryption PR (in-review) [#474](https://github.com/logos-blockchain/logos-execution-zone/pull/474)
+  - LEE key protocol specs draft started [#505](https://github.com/logos-blockchain/logos-execution-zone/pull/505)
+
+- `blockchain:logos-execution-zone:logos-core`
+  - Keycard and lez-module updates unified [logos-execution-zone#500](https://github.com/logos-blockchain/logos-execution-zone/pull/500)
+  - Wallet FFI extended to expose generic transaction flows (in-review) [#491](https://github.com/logos-blockchain/logos-execution-zone/pull/491)
+
+- `blockchain:logos-execution-zone:benchmarks`
+  - Bench-regression CI workflow for `crypto_primitives_bench` merged [logos-execution-zone#494](https://github.com/logos-blockchain/logos-execution-zone/pull/494)
+  - Sequencer benchmarks on Raspberry Pi 5 — standalone-sequencer pass complete, full-stack L1 measurements started ([findings summary](https://discord.com/channels/973324189794697286/1510311004318466180))
+
+- `blockchain:logos-execution-zone:bridging`
+  - Sequencer-side Bridge Deposit flow merged [logos-execution-zone#493](https://github.com/logos-blockchain/logos-execution-zone/pull/493)
+  - Bridge Deposit fault-tolerance follow-up (in-review) [#506](https://github.com/logos-blockchain/logos-execution-zone/pull/506)
+
+- `blockchain:logos-execution-zone:deployment`
+  - CI integration tests sped up [logos-execution-zone#498](https://github.com/logos-blockchain/logos-execution-zone/pull/498)
+  - Protocol fixes found while updating LEZ specs merged [#504](https://github.com/logos-blockchain/logos-execution-zone/pull/504)
+
+## `nimbos`
+
+- Mantle ledger merged: makes use of persistent datastructures to support efficient state sharing between forks [nimbos#46](https://github.com/logos-co/nimbos/pull/46)
+- Genesis-from-deployment post-merge review fixes [nimbos#49](https://github.com/logos-co/nimbos/pull/49)
+- Genesis Mantle tx vectors: optional types aligned with `nim-results` `Opt`, Poseidon2 `Option` bridge in hasher, Merkle leaf `Opt[Item]`, stale `std/options` imports dropped (in-review) [nimbos#45](https://github.com/logos-co/nimbos/pull/45)


### PR DESCRIPTION
## Summary

Weekly blockchain update for the iteration 2026-05-25 → 2026-05-31.

Highlights:
- Sequencer-side Bridge Deposit flow merged on LEZ (indexer side still to come)
- Circuits witness binaries dropped — circuits now consumed as Rust crates; prover binaries still to be removed
- Nimbos Mantle ledger merged with persistent datastructures for efficient cross-fork state sharing

## Test plan
- [ ] Verify rendered weekly update at content/blockchain/updates/2026-06-01.md