### PR TITLE
docs(messaging): sync roadmap with pm repo issues

### DIFF
--- a/content/messaging/roadmap/index.md
+++ b/content/messaging/roadmap/index.md
@@ -41,8 +41,8 @@ We use three release stages for developer-facing APIs and libraries:
 - [x] [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
 - [x] [Chat — Developer Preview](2026-chat-developer-preview)
 - [ ] [Logos Core Integration — Phase 2](2026-logos-core-integration-phase-2)
-- [ ] [QUIC Transport in Logos Delivery](2025-support-discovery-research-and-libp2p-quic)
-- [ ] [RLN for Edge Nodes](2026-rln-for-edge-nodes.md)
+- [ ] [Support QUIC Transport in Logos Delivery](2025-support-discovery-research-and-libp2p-quic)
+- [x] [RLN for Edge Nodes](2026-rln-for-edge-nodes.md)
 
 ### Testnet [v0.3](v03)
 

--- a/content/messaging/roadmap/milestones/2024-e2e-reliability-protocol.md
+++ b/content/messaging/roadmap/milestones/2024-e2e-reliability-protocol.md
@@ -58,3 +58,7 @@ For S1. Applied to Communities channels on Status Desktop
 - P3. When receiving messages in group, the receiver can reach eventual consistency within `6*S` seconds **(Vac-DST)**
 
 For S1. Applied to Communities channels on Status Desktop
+
+## [SDS protocol in Status — enable wrapping for communities messages](https://github.com/logos-messaging/pm/issues/385)
+
+**Owner**: Delivery Team + Status Core

--- a/content/messaging/roadmap/milestones/2025-support-discovery-research-and-libp2p-quic.md
+++ b/content/messaging/roadmap/milestones/2025-support-discovery-research-and-libp2p-quic.md
@@ -1,8 +1,9 @@
 ---
-title: QUIC Transport in Logos Delivery
+title: Support QUIC Transport in Logos Delivery
 tags:
   - messaging-milestone
 date: 2025-12-03
+github: https://github.com/logos-messaging/pm/issues/404
 ---
 
 
@@ -22,7 +23,7 @@ Replace legacy multiplexers (Yamux, Mplex) with QUIC transport. The old multiple
 
 ## Deliverables
 
-### [Trial QUIC](https://github.com/waku-org/pm/issues/324)
+### [Trial QUIC](https://github.com/logos-messaging/pm/issues/324)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-add-support-for-rln-on-lee.md
+++ b/content/messaging/roadmap/milestones/2026-add-support-for-rln-on-lee.md
@@ -92,7 +92,7 @@ Adopt Zerokit 2.0 in `logos-delivery` on `master`, in coordination with AnonComm
 - U1. RLN membership details can be exported and imported.
 - U2. Deployment details (backend type, address/endpoint) are persisted by library and in exports.
 
-### Enable RLN in Logos Devnet
+### [Enable RLN in Logos Devnet](https://github.com/logos-messaging/pm/issues/451)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-chat-beta.md
+++ b/content/messaging/roadmap/milestones/2026-chat-beta.md
@@ -3,6 +3,7 @@ title: Chat — Beta
 tags:
   - messaging-milestone
 date: 2026-01-15
+github: https://github.com/logos-messaging/pm/issues/425
 ---
 
 
@@ -35,7 +36,7 @@ The focus is:
 
 ## Deliverables
 
-### Implement full identity model
+### [Implement full identity model](https://github.com/logos-messaging/pm/issues/439)
 
 **Owner**: Chat Team
 
@@ -46,7 +47,7 @@ Building on the simple identity model from v0.2:
 - Optional binding to external identity systems
 - Specification and implementation, in collaboration with AnonComms team
 
-### Stabilize and polish API
+### [Stabilize and polish API](https://github.com/logos-messaging/pm/issues/440)
 
 **Owner**: Chat Team
 
@@ -54,7 +55,7 @@ Building on the simple identity model from v0.2:
 - Fix API inconsistencies and footguns discovered during integration
 - Stabilize error handling and edge cases
 
-### Deliver user-facing chat features
+### [Deliver user-facing chat features](https://github.com/logos-messaging/pm/issues/441)
 
 **Owner**: Chat Team
 
@@ -64,7 +65,7 @@ Features needed for a real chat experience beyond the protocol layer:
 - Conversation list management
 - Typing indicators and read receipts
 
-### Reliability testing with DST
+### [Reliability testing with DST](https://github.com/logos-messaging/pm/issues/442)
 
 **Owner**: Chat Team + DST
 
@@ -74,7 +75,7 @@ Features needed for a real chat experience beyond the protocol layer:
 - Performance testing against FURPS targets (10K users, 10Mbps bandwidth)
 - Scale testing with up to 201 users in a group chat
 
-### Add support for Logos Delivery RLN
+### [Add support for Logos Delivery RLN](https://github.com/logos-messaging/pm/issues/443)
 
 **Owner**: Chat Team
 
@@ -82,13 +83,13 @@ Logos Chat works against RLN-enforcing networks: chat traffic sent through Logos
 
 **Dependency**: [RLN for Edge Nodes](2026-rln-for-edge-nodes.md) must be delivered.
 
-### Perform test integration of Logos Chat into Status App
+### [Perform test integration of Logos Chat into Status App](https://github.com/logos-messaging/pm/issues/444)
 
 **Owner**: Chat Team + Status Team
 
 Initial validation that Logos Chat (1:1 + group chats) can be consumed by Status. This is an exploratory integration, not a production milestone. The goal is to get feedback on the API from a production app.
 
-### Design SDS and de-MLS integration
+### [Design SDS and de-MLS integration](https://github.com/logos-messaging/pm/issues/445)
 
 **Owner**: Chat Team
 

--- a/content/messaging/roadmap/milestones/2026-chat-beta.md
+++ b/content/messaging/roadmap/milestones/2026-chat-beta.md
@@ -75,7 +75,7 @@ Features needed for a real chat experience beyond the protocol layer:
 - Performance testing against FURPS targets (10K users, 10Mbps bandwidth)
 - Scale testing with up to 201 users in a group chat
 
-### [Add support for Logos Delivery RLN](https://github.com/logos-messaging/pm/issues/443)
+### [Add support for Logos Delivery RLN](https://github.com/logos-messaging/pm/issues/347)
 
 **Owner**: Chat Team
 

--- a/content/messaging/roadmap/milestones/2026-chat-general-availability.md
+++ b/content/messaging/roadmap/milestones/2026-chat-general-availability.md
@@ -3,6 +3,7 @@ title: Chat — General Availability
 tags:
   - messaging-milestone
 date: 2026-03-01
+github: https://github.com/logos-messaging/pm/issues/426
 ---
 
 
@@ -32,7 +33,7 @@ Logos Chat is feature-complete, production-ready, and QA-approved for mainnet de
 
 ## Deliverables
 
-### Production scale testing
+### [Production scale testing](https://github.com/logos-messaging/pm/issues/453)
 
 **Owner**: Chat Team + DST
 
@@ -40,7 +41,7 @@ Logos Chat is feature-complete, production-ready, and QA-approved for mainnet de
 - Performance optimization based on testing results
 - Stress testing group chats at community scale
 
-### Production documentation
+### [Production documentation](https://github.com/logos-messaging/pm/issues/454)
 
 **Owner**: Chat Team
 
@@ -50,7 +51,7 @@ Logos Chat is feature-complete, production-ready, and QA-approved for mainnet de
 - Content topic design guidelines for auto-sharding
 - Production deployment guide
 
-### API stability
+### [API stability](https://github.com/logos-messaging/pm/issues/455)
 
 **Owner**: Chat Team
 
@@ -58,7 +59,7 @@ Logos Chat is feature-complete, production-ready, and QA-approved for mainnet de
 - Deprecation policy for any future changes
 - Versioning strategy
 
-### Validate integration in Status
+### [Validate integration in Status](https://github.com/logos-messaging/pm/issues/456)
 
 **Owner**: Chat Team + Status Team
 

--- a/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-2.md
+++ b/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-2.md
@@ -3,6 +3,7 @@ title: Logos Core Integration — Phase 2
 tags:
   - messaging-milestone
 date: 2026-01-19
+github: https://github.com/logos-messaging/pm/issues/397
 ---
 
 

--- a/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-3.md
+++ b/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-3.md
@@ -3,6 +3,7 @@ title: Logos Core Integration — Phase 3
 tags:
   - messaging-milestone
 date: 2026-07-07
+github: https://github.com/logos-messaging/pm/issues/421
 ---
 
 **Resources Required**:
@@ -13,7 +14,7 @@ The v0.3 stage of Logos Core integration. Building on [Phase 2](2026-logos-core-
 
 ## Deliverables
 
-### Pluggable RLN membership
+### [Pluggable RLN membership](https://github.com/logos-messaging/pm/issues/446)
 
 **Owner**: Delivery Team
 
@@ -29,19 +30,19 @@ Note that "making RLN pluggable" has different parts:
 
 **Done when**: An RLN membership backend can be swapped — including one provided by a Logos Core module — without changes to `logos-delivery` internals. Exercised by the POC below.
 
-### POC: Integrate RLN module
+### [POC: Integrate RLN module](https://github.com/logos-messaging/pm/issues/447)
 
 **Owner**: Delivery Team
 
 Proof of concept: the Delivery module obtains RLN credentials and validates proofs through the RLN membership Logos Core module (from AnonComms), instead of interacting with the blockchain directly. Validates the module interface ahead of the full integration (see deliverable below).
 
-### Delivery module uses RLN membership module
+### [Delivery module uses RLN membership module](https://github.com/logos-messaging/pm/issues/448)
 
 **Owner**: Delivery Team
 
 Logos Delivery module obtains RLN credentials and validates proofs through the RLN membership Logos Core module rather than direct blockchain interaction.
 
-### Make discovery pluggable in Logos Delivery
+### [Make discovery pluggable in Logos Delivery](https://github.com/logos-messaging/pm/issues/449)
 
 **Owner**: Delivery Team
 
@@ -49,7 +50,7 @@ Peer discovery is extracted behind a kernel discovery interface, with the embedd
 
 **Done when**: The Discovery Logos Core module can be added as a peer source (see the POC below) without kernel changes, enabling the full replacement of discv5 in [Phase 4](2026-logos-core-integration-phase-4.md).
 
-### POC: Delivery module uses Discovery module for peer discovery
+### [POC: Delivery module uses Discovery module for peer discovery](https://github.com/logos-messaging/pm/issues/389)
 
 **Owner**: Delivery Team
 
@@ -57,7 +58,7 @@ Proof of concept: the Delivery module uses the Discovery Logos Core module (from
 
 This is a POC — the full replacement of embedded discv5 happens in [Phase 4](2026-logos-core-integration-phase-4.md).
 
-### Enable QUIC in `logos.dev` and `logos.test`
+### [Enable QUIC in `logos.dev` and `logos.test`](https://github.com/logos-messaging/pm/issues/450)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-3.md
+++ b/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-3.md
@@ -28,19 +28,13 @@ Note that "making RLN pluggable" has different parts:
   - Main part (current scope): RLN membership library
   - Extra part (next, to be aligned with AnonComms): generate/validate proofs using external RLN module too.
 
-**Done when**: An RLN membership backend can be swapped — including one provided by a Logos Core module — without changes to `logos-delivery` internals. Exercised by the POC below.
-
-### [POC: Integrate RLN module](https://github.com/logos-messaging/pm/issues/447)
-
-**Owner**: Delivery Team
-
-Proof of concept: the Delivery module obtains RLN credentials and validates proofs through the RLN membership Logos Core module (from AnonComms), instead of interacting with the blockchain directly. Validates the module interface ahead of the full integration (see deliverable below).
+**Done when**: An RLN membership backend can be swapped — including one provided by a Logos Core module — without changes to `logos-delivery` internals. Exercised by the [Delivery module uses RLN membership module](https://github.com/logos-messaging/pm/issues/448) deliverable below.
 
 ### [Delivery module uses RLN membership module](https://github.com/logos-messaging/pm/issues/448)
 
 **Owner**: Delivery Team
 
-Logos Delivery module obtains RLN credentials and validates proofs through the RLN membership Logos Core module rather than direct blockchain interaction.
+Logos Delivery module obtains RLN credentials and validates proofs through the RLN membership Logos Core module rather than direct blockchain interaction, validating the module interface developed with AnonComms.
 
 ### [Make discovery pluggable in Logos Delivery](https://github.com/logos-messaging/pm/issues/449)
 

--- a/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-4.md
+++ b/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-4.md
@@ -3,6 +3,7 @@ title: Logos Core Integration — Phase 4
 tags:
   - messaging-milestone
 date: 2026-03-01
+github: https://github.com/logos-messaging/pm/issues/427
 ---
 
 
@@ -33,7 +34,7 @@ This enables a fully modular Logos Core deployment where all modules share infra
 
 ## Deliverables
 
-### Delivery module uses Discovery module
+### [Delivery module uses Discovery module](https://github.com/logos-messaging/pm/issues/452)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-messaging-api-beta.md
+++ b/content/messaging/roadmap/milestones/2026-messaging-api-beta.md
@@ -29,7 +29,7 @@ Comprehensive documentation and production readiness are delivered in [General A
 
 ## Deliverables
 
-### Provide Store API access for Status needs
+### [Provide Store API access for Status needs](https://github.com/logos-messaging/pm/issues/463)
 
 **Owner**: Delivery Team
 
@@ -42,7 +42,7 @@ Either introduce a new Store API (next to Messaging API), or allow using low-lev
 
 Note that Store protocol was intentionally left out of Messaging API. But we should provide a solution for existing apps, e.g. Status.
 
-### Test suite for Messaging API
+### [Test suite for Messaging API](https://github.com/logos-messaging/pm/issues/422)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-messaging-api-general-availability.md
+++ b/content/messaging/roadmap/milestones/2026-messaging-api-general-availability.md
@@ -3,6 +3,7 @@ title: Messaging API — General Availability
 tags:
   - messaging-milestone
 date: 2026-07-07
+github: https://github.com/logos-messaging/pm/issues/424
 ---
 
 The [Beta](2026-messaging-api-beta.md) delivered the full API surface (Send, Health, Subscribe/Receive in core and edge mode), while allowing to use Kernel API for Store access for existing applications. General Availability makes the Messaging API production-ready: DST-validated reliability at scale, automatic recovery of messages missed while offline, built-in rate limit management and anonymity via mix integration.
@@ -22,7 +23,7 @@ The [Beta](2026-messaging-api-beta.md) delivered the full API surface (Send, Hea
 
 ## Deliverables
 
-### Reliability and scale validation with DST
+### [Reliability and scale validation with DST](https://github.com/logos-messaging/pm/issues/429)
 
 **Owner**: Delivery Team + DST
 
@@ -30,7 +31,7 @@ The Messaging API is QA-approved for production use. DST validates reliability a
 
 **Done when**: A DST test report covering reliability and scale targets is available, and QA sign-off is obtained.
 
-### Offline periods backfill
+### [Offline periods backfill](https://github.com/logos-messaging/pm/issues/430)
 
 **Owner**: Delivery Team
 
@@ -43,11 +44,11 @@ Messages missed while a node was offline are retrieved automatically on reconnec
 
 **Done when**: After an offline period, a subscribed application receives all missed messages through its existing subscription, with no additional API calls.
 
-### Create Rate Limit Manager
+### [Create Rate Limit Manager](https://github.com/logos-messaging/pm/issues/431)
 
-https://github.com/logos-messaging/pm/issues/319
+**Owner**: Delivery Team
 
-**Owner**: Chat Team
+Note: a basic implementation already exists in `logos_delivery/channels/rate_limit_manager/` (queue + epoch reset). This deliverable completes it per the FURPS below (priorities, batching, persistence).
 
 **Feature**: [Rate Limit Manager](/messaging/furps/application/rate_limit_manager.md)
 
@@ -71,7 +72,7 @@ https://github.com/logos-messaging/pm/issues/319
 - S1. Nim library.
 - +1. Nimble package manager is used to build.
 
-### Integrate Rate Limit manager
+### [Integrate Rate Limit Manager](https://github.com/logos-messaging/pm/issues/432)
 
 **Owner**: Delivery Team
 
@@ -81,7 +82,7 @@ Integrate the Rate Limit Manager (created in [Reliable Channel API — Beta](202
 
 **Done when**: The Messaging API send path enforces the rate limit with message priorities, using a single per-node quota.
 
-### Integrate Mix into Messaging API
+### [Integrate Mix into Messaging API](https://github.com/logos-messaging/pm/issues/433)
 
 **Owner**: Delivery Team
 
@@ -102,7 +103,7 @@ Behind the MessagingAPI, Mix discovery should be started when needed and Mix pro
 
 **Done when**: Messages sent through the Messaging API are routed over the mix network by default, with no application changes required.
 
-### Provide documentation on the API
+### [Provide documentation on the Messaging API](https://github.com/logos-messaging/pm/issues/434)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
+++ b/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
@@ -58,7 +58,7 @@ https://github.com/logos-messaging/pm/issues/318
 - +2. Relevant for all Logos Delivery nodes.
 - +3. Nimble package manager is used to build.
 
-### [Add Segmentation to Reliable Channel API](https://github.com/logos-messaging/pm/issues/435)
+### [Add Segmentation to Reliable Channel API](https://github.com/logos-messaging/logos-delivery/issues/3854)
 
 **Owner**: Delivery Team
 
@@ -78,7 +78,7 @@ https://github.com/logos-messaging/pm/issues/318
 **FURPS**:
 - ~~F4. Missing messages are automatically retrieved via store hash queries.~~
 
-### [Support different encryption for sync messages](https://github.com/logos-messaging/pm/issues/437)
+### [Support different encryption for sync messages](https://github.com/logos-messaging/logos-delivery/issues/3856)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
+++ b/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
@@ -58,7 +58,7 @@ https://github.com/logos-messaging/pm/issues/318
 - +2. Relevant for all Logos Delivery nodes.
 - +3. Nimble package manager is used to build.
 
-### Add Segmentation to Reliable Channel API
+### [Add Segmentation to Reliable Channel API](https://github.com/logos-messaging/pm/issues/435)
 
 **Owner**: Delivery Team
 
@@ -69,7 +69,7 @@ https://github.com/logos-messaging/pm/issues/318
 - R2. Segments tracked independently and reassembled before delivery (via event emission).
 - P2. Final encoded routed message stays below 150 KB routing layer limit.
 
-### Deprecate store hash queries for missing messages
+### [Deprecate store hash queries for missing messages](https://github.com/logos-messaging/pm/issues/436)
 
 **Owner**: Delivery Team
 
@@ -78,7 +78,7 @@ https://github.com/logos-messaging/pm/issues/318
 **FURPS**:
 - ~~F4. Missing messages are automatically retrieved via store hash queries.~~
 
-### Support different encryption for sync messages
+### [Support different encryption for sync messages](https://github.com/logos-messaging/pm/issues/437)
 
 **Owner**: Delivery Team
 
@@ -87,7 +87,7 @@ https://github.com/logos-messaging/pm/issues/318
 **FURPS**:
 - F11. A different encryption mechanism can be applied for sync messages (than the one for content messages).
 
-### Provide documentation on the API
+### [Provide documentation on the Reliable Channel API](https://github.com/logos-messaging/pm/issues/438)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-rln-for-edge-nodes.md
+++ b/content/messaging/roadmap/milestones/2026-rln-for-edge-nodes.md
@@ -21,7 +21,7 @@ It's an open question, how edge nodes will get RLN memberships. The initial impl
 | RLN membership sponsorship model is not defined | Focus on no-sponsorship implementation first. |
 ## Deliverables
 
-### Add support for RLN proofs in LightPush
+### [Add support for RLN proofs in LightPush](https://github.com/logos-messaging/pm/issues/423)
 
 **Owner**: Delivery Team
 
@@ -33,7 +33,7 @@ This decouples lightpush from service node quota entirely for clients that have 
 
 Note that this might already be possible in `logos-delivery`, in that case it needs verification.
 
-### [Improve RLN UX by reducing contract interactions](https://github.com/waku-org/pm/issues/344)
+### [Improve RLN UX by reducing contract interactions](https://github.com/logos-messaging/pm/issues/344)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-status-logos-chat-integration.md
+++ b/content/messaging/roadmap/milestones/2026-status-logos-chat-integration.md
@@ -48,7 +48,7 @@ Status switches from its current chat protocol implementation to Logos Chat, con
 
 ## Deliverables
 
-### Integrate Logos Chat 1:1 chats in Status
+### [Integrate Logos Chat 1:1 chats in Status](https://github.com/logos-messaging/pm/issues/460)
 
 **Owner**: Chat Team + Status Core
 
@@ -57,7 +57,7 @@ Status switches from its current chat protocol implementation to Logos Chat, con
 - Migration path from existing Status 1:1 chat protocol
 - Go bindings via C-bindings from Logos Core
 
-### Integrate Logos Chat group chats in Status
+### [Integrate Logos Chat group chats in Status](https://github.com/logos-messaging/pm/issues/461)
 
 **Owner**: Chat Team + Status Core
 
@@ -65,7 +65,7 @@ Status switches from its current chat protocol implementation to Logos Chat, con
 - Migration path from existing Status group chat protocol
 - Multi-device support through de-MLS installations
 
-### Define communities architecture on Logos Chat
+### [Define communities architecture on Logos Chat](https://github.com/logos-messaging/pm/issues/462)
 
 **Owner**: Status Core (with Messaging team advisory)
 

--- a/content/messaging/roadmap/milestones/2026-support-mobile-platforms.md
+++ b/content/messaging/roadmap/milestones/2026-support-mobile-platforms.md
@@ -3,6 +3,7 @@ title: Support Mobile Platforms
 tags:
   - messaging-milestone
 date: 2026-02-21
+github: https://github.com/logos-messaging/pm/issues/428
 ---
 
 
@@ -35,7 +36,7 @@ This involves three areas:
 
 ## Deliverables
 
-### Ensure nim-ffi libraries work on mobile platforms
+### [Ensure nim-ffi libraries work on mobile platforms](https://github.com/logos-messaging/pm/issues/457)
 
 **Owner**: Delivery Team
 
@@ -44,7 +45,7 @@ This involves three areas:
 **FURPS**:
 - S2. The exposed C library can be used in Logos Core for mobile: iOS and Android.
 
-### Verify and test edge mode on mobile
+### [Verify and test edge mode on mobile](https://github.com/logos-messaging/pm/issues/458)
 
 **Owner**: Delivery Team + DST
 
@@ -54,7 +55,7 @@ Edge mode is implemented in [Messaging API — Beta](2026-messaging-api-beta.md)
 - Performance tuning for mobile constraints
 - DST validation of reliability in edge mode on mobile
 
-### Verify Chat and Delivery modules on Logos Core mobile
+### [Verify Chat and Delivery modules on Logos Core mobile](https://github.com/logos-messaging/pm/issues/459)
 
 **Owner**: Delivery Team + Chat Team
 

--- a/content/messaging/templates/weekly-update-template.md
+++ b/content/messaging/templates/weekly-update-template.md
@@ -182,11 +182,6 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-- [[Deliverable] POC: Integrate RLN module](https://github.com/logos-messaging/pm/issues/447)
-  - achieved:
-  - next:
-  - blockers:
-
 - [[Deliverable] Delivery module uses RLN membership module](https://github.com/logos-messaging/pm/issues/448)
   - achieved:
   - next:

--- a/content/messaging/templates/weekly-update-template.md
+++ b/content/messaging/templates/weekly-update-template.md
@@ -15,33 +15,34 @@ title: 2026-MM-DD Messaging Weekly
 
 # Logos Delivery
 
-## [Messaging API — Beta](2026-messaging-api-beta.md)
-
-- [Deliverable] Provide Store API access for Status needs
-  - achieved:
-  - next:
-  - blockers:
-
-- [Deliverable] Test suite for Messaging API
-  - achieved:
-  - next:
-  - blockers:
-
-- [[Deliverable] Stabilize and improve Messaging API, fix bugs](https://github.com/logos-messaging/pm/issues/414)
-  - achieved:
-  - next:
-  - blockers:
-
 ## [Messaging API — General Availability](2026-messaging-api-general-availability.md)
 
-- [Deliverable] Provide documentation on the API
+- [[Deliverable] Reliability and scale validation with DST](https://github.com/logos-messaging/pm/issues/429)
   - achieved:
   - next:
   - blockers:
 
-## [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md)
+- [[Deliverable] Offline periods backfill](https://github.com/logos-messaging/pm/issues/430)
+  - achieved:
+  - next:
+  - blockers:
 
-- [[Deliverable] Implement Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
+- [[Deliverable] Create Rate Limit Manager](https://github.com/logos-messaging/pm/issues/431)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Integrate Rate Limit Manager](https://github.com/logos-messaging/pm/issues/432)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Integrate Mix into Messaging API](https://github.com/logos-messaging/pm/issues/433)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Provide documentation on the Messaging API](https://github.com/logos-messaging/pm/issues/434)
   - achieved:
   - next:
   - blockers:
@@ -53,22 +54,22 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-- [[Deliverable] Implement RLN membership management in nwaku library](https://github.com/logos-messaging/pm/issues/353)
+- [[Deliverable] Add Segmentation to Reliable Channel API](https://github.com/logos-messaging/logos-delivery/issues/3854)
   - achieved:
   - next:
   - blockers:
 
-- Add Segmentation to Reliable Channel API
+- [[Deliverable] Deprecate store hash queries for missing messages](https://github.com/logos-messaging/pm/issues/436)
   - achieved:
   - next:
   - blockers:
 
-- Add Rate Limit Manager to Reliable Channel API
+- [[Deliverable] Support different encryption for sync messages](https://github.com/logos-messaging/logos-delivery/issues/3856)
   - achieved:
   - next:
   - blockers:
 
-- Deprecate store hash queries for missing messages
+- [[Deliverable] Provide documentation on the Reliable Channel API](https://github.com/logos-messaging/pm/issues/438)
   - achieved:
   - next:
   - blockers:
@@ -80,14 +81,7 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-## [RLN for Edge Nodes](https://github.com/logos-messaging/pm/issues/411)
-
-- [[Deliverable] Improve RLN UX by reducing contract interactions](https://github.com/logos-messaging/pm/issues/344)
-  - achieved:
-  - next:
-  - blockers:
-
-## [Port RLN to Logos Blockchain](2026-add-support-for-rln-on-lee.md)
+## [RLN on Logos Blockchain](2026-add-support-for-rln-on-lee.md)
 
 - [[Deliverable] Implement pluggable RLN membership interface](https://github.com/logos-messaging/pm/issues/416)
   - achieved:
@@ -99,24 +93,19 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-- [[Deliverable] Update RLN membership management library](https://github.com/logos-messaging/pm/issues/419)
+- [[Deliverable] Implement RLN membership management API](https://github.com/logos-messaging/pm/issues/419)
   - achieved:
   - next:
   - blockers:
 
-## [Fleet stability](2026-fleet-stability.md)
-
-- [[Deliverable] Integrate Sentry for crash reporting](https://github.com/logos-messaging/pm/issues/381)
+- [[Deliverable] Enable RLN in Logos Devnet](https://github.com/logos-messaging/pm/issues/451)
   - achieved:
   - next:
   - blockers:
+
+## [Fleet Stability](2026-fleet-stability.md)
 
 - [[Deliverable] Fleet monitoring dashboards for Logos fleets](https://github.com/logos-messaging/pm/issues/382)
-  - achieved:
-  - next:
-  - blockers:
-
-- [[Deliverable] Fleet alerting for Logos fleets](https://github.com/logos-messaging/pm/issues/383)
   - achieved:
   - next:
   - blockers:
@@ -135,61 +124,48 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-- [[Deliverable] Enable usage with RLN SDK](https://github.com/logos-messaging/pm/issues/347)
+## [Chat — Beta](2026-chat-beta.md)
+
+- [[Deliverable] Implement full identity model](https://github.com/logos-messaging/pm/issues/439)
   - achieved:
   - next:
   - blockers:
 
-- Implement simple identity model
+- [[Deliverable] Stabilize and polish API](https://github.com/logos-messaging/pm/issues/440)
   - achieved:
   - next:
   - blockers:
 
-- Implement contact discovery
+- [[Deliverable] Deliver user-facing chat features](https://github.com/logos-messaging/pm/issues/441)
   - achieved:
   - next:
   - blockers:
 
-- Design SDS and de-MLS integration
+- [[Deliverable] Reliability testing with DST](https://github.com/logos-messaging/pm/issues/442)
   - achieved:
   - next:
   - blockers:
 
-- Remove unnecessary Nim shim from Logos Chat
+- [[Deliverable] Add support for Logos Delivery RLN](https://github.com/logos-messaging/pm/issues/347)
   - achieved:
   - next:
   - blockers:
 
-- Perform test integration of Logos Chat into Status App
+- [[Deliverable] Perform test integration of Logos Chat into Status App](https://github.com/logos-messaging/pm/issues/444)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Design SDS and de-MLS integration](https://github.com/logos-messaging/pm/issues/445)
   - achieved:
   - next:
   - blockers:
 
 # Logos Core
 
-## [Logos Core integration — phase 2](2026-logos-core-integration-phase-2.md)
-
-- [[Deliverable] Integrate Chat and Delivery Logos Core modules](https://github.com/logos-messaging/pm/issues/387)
-  - achieved:
-  - next:
-  - blockers:
-
-- [[Deliverable] Add support for groups in Logos Core Chat module](https://github.com/logos-messaging/pm/issues/375)
-  - achieved:
-  - next:
-  - blockers:
+## [Logos Core Integration — Phase 2](2026-logos-core-integration-phase-2.md)
 
 - [[Deliverable] Add Reliable Channel API to Logos Core Delivery module](https://github.com/logos-messaging/pm/issues/388)
-  - achieved:
-  - next:
-  - blockers:
-
-- [[Deliverable] POC: Delivery module uses Discovery module for peer discovery](https://github.com/logos-messaging/pm/issues/389)
-  - achieved:
-  - next:
-  - blockers:
-
-- [[Deliverable] Build Logos Core demo app in QML](https://github.com/logos-messaging/pm/issues/390)
   - achieved:
   - next:
   - blockers:
@@ -199,9 +175,41 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
+## [Logos Core Integration — Phase 3](2026-logos-core-integration-phase-3.md)
+
+- [[Deliverable] Pluggable RLN membership](https://github.com/logos-messaging/pm/issues/446)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] POC: Integrate RLN module](https://github.com/logos-messaging/pm/issues/447)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Delivery module uses RLN membership module](https://github.com/logos-messaging/pm/issues/448)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Make discovery pluggable in Logos Delivery](https://github.com/logos-messaging/pm/issues/449)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] POC: Delivery module uses Discovery module for peer discovery](https://github.com/logos-messaging/pm/issues/389)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Enable QUIC in logos.dev and logos.test](https://github.com/logos-messaging/pm/issues/450)
+  - achieved:
+  - next:
+  - blockers:
+
 # Status
 
-## [Integrate logos-delivery in Status](2026-status-logos-delivery-integration.md)
+## [Status: Logos Delivery Integration](2026-status-logos-delivery-integration.md)
 
 - [[Deliverable] Integrate Messaging API in status-go](https://github.com/logos-messaging/pm/issues/380)
   - achieved:
@@ -210,7 +218,7 @@ title: 2026-MM-DD Messaging Weekly
 
 ## [Introduce E2E Reliability in Status Communities](2024-e2e-reliability-protocol.md)
 
-- [[Deliverable] SDS protocol in Status - basic recovery](https://github.com/logos-messaging/pm/issues/304)
+- [[Deliverable] SDS protocol in Status — basic recovery](https://github.com/logos-messaging/pm/issues/304)
   - achieved:
   - next:
   - blockers:
@@ -220,9 +228,24 @@ title: 2026-MM-DD Messaging Weekly
   - next:
   - blockers:
 
-## [Integrate logos-chat in Status](2026-status-logos-chat-integration.md)
+## [Status: Logos Chat Integration](2026-status-logos-chat-integration.md)
 
 - [[Deliverable] Deploy RLN Contracts to Status L2 testnet](https://github.com/logos-messaging/pm/issues/356)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Integrate Logos Chat 1:1 chats in Status](https://github.com/logos-messaging/pm/issues/460)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Integrate Logos Chat group chats in Status](https://github.com/logos-messaging/pm/issues/461)
+  - achieved:
+  - next:
+  - blockers:
+
+- [[Deliverable] Define communities architecture on Logos Chat](https://github.com/logos-messaging/pm/issues/462)
   - achieved:
   - next:
   - blockers:


### PR DESCRIPTION
Two-way sync between the messaging roadmap and [logos-messaging/pm](https://github.com/logos-messaging/pm/issues) after the v0.3 restructure (#491):

**GitHub side (already done, not in this PR):** renamed #396, #401, #402, #408, #411, #419, #421 to match roadmap titles; created 5 milestone issues (#424 Messaging API — GA, #425 Chat — Beta, #426 Chat — GA, #427 Logos Core Integration — Phase 4, #428 Support Mobile Platforms) and 35 typed, parented deliverable issues (#429–#463) with release assignments.

**Roadmap side (this PR):**
- `github:` frontmatter added to all milestones that lacked it (incl. the 5 new issues)
- All deliverable headings linked to their pm issues
- RLN for Edge Nodes marked done (pm#411 closed with all deliverables)
- QUIC milestone retitled 'Support QUIC Transport in Logos Delivery' to match pm#404
- 'Create Rate Limit Manager' relinked from stale Chat-era #319 to new #431, noting the basic implementation that already exists in `logos_delivery/channels/rate_limit_manager/`
- Old `waku-org/pm` links repointed to `logos-messaging/pm` (#324, #344)
- Missing #385 deliverable added to E2E Reliability milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)