### PR TITLE
docs(messaging): extract Installation management deliverable

### DIFF
--- a/content/messaging/roadmap/milestones/2026-chat-beta.md
+++ b/content/messaging/roadmap/milestones/2026-chat-beta.md
@@ -47,6 +47,23 @@ Building on the simple identity model from v0.2:
 - Optional binding to external identity systems
 - Specification and implementation, in collaboration with AnonComms team
 
+Installation (device) lifecycle is covered separately by [Installation management](#installation-management).
+
+### Installation management
+
+**Owner**: Chat Team
+
+Extracted from [Add Group Chat](https://github.com/logos-messaging/pm/issues/346): the installation (device) lifecycle for accounts. The current implementation registers installation keys and key packages, but installations cannot yet be listed, removed, or revoked, and known gaps prevent true multi-device usage: one-time key packages limit a member to a single conversation ([libchat#169](https://github.com/logos-messaging/libchat/issues/169)), installation keys are not persisted across sessions ([libchat#28](https://github.com/logos-messaging/libchat/issues/28)), and multiple installations cannot resolve to a single account ([libchat#109](https://github.com/logos-messaging/libchat/issues/109)).
+
+**Feature**: [Group Chat](/messaging/furps/application/group_chat.md)
+
+**FURPS**:
+- F1. Accounts can receive a message in multiple locations (e.g. devices) by registering new installations.
+- F2. Accounts can view and remove installations as needed.
+- F5. Account can view all provisioned installations.
+- F6. Account can revoke other installations in case of a lost device.
+- +PRIV2. No identifying information is visible when registering an installation — to be addressed by design in the key package registry replacement ([libchat#110](https://github.com/logos-messaging/libchat/issues/110) is an interim testnet service).
+
 ### [Stabilize and polish API](https://github.com/logos-messaging/pm/issues/440)
 
 **Owner**: Chat Team

--- a/content/messaging/roadmap/milestones/2026-chat-developer-preview.md
+++ b/content/messaging/roadmap/milestones/2026-chat-developer-preview.md
@@ -42,19 +42,16 @@ Group chat features will be limited at this stage and extended with further mile
 **Feature**: [Group Chat](/messaging/furps/application/group_chat.md)
 
 **FURPS**:
-- F1. Accounts can receive a message in multiple locations (e.g. devices) by registering new installations.
-- F2. Accounts can view and remove installations as needed.
 - F3. Accounts can create group chats between multiple accounts.
 - F4. Participants can set a group name and description for all participants in the group.
-- F5. Account can view all provisioned installations.
-- F6. Account can revoke other installations in case of a lost device.
 
 - R1. Group participants in a conversation can tell if a message is missing, and who sent it.
 
 - P1. The number of network messages for a single outbound group message does not scale with the number of group members.
 
 - +PRIV1. Non-participants cannot correlate a group conversation to any of its participants.
-- +PRIV2. No identifying information is visible when registering an installation.
+
+Installation-related FURPS (F1, F2, F5, F6, +PRIV2) moved to [Installation management](2026-chat-beta#installation-management) in Chat — Beta.
 
 ### Implement simple identity model
 


### PR DESCRIPTION
Carves the installation (device) lifecycle out of [Add Group Chat (pm#346)](https://github.com/logos-messaging/pm/issues/346) into a dedicated **Installation management** deliverable under Chat — Beta.