### PR TITLE
docs(messaging): cosmetic fixes from roadmap review

### DIFF
--- a/content/messaging/roadmap/index.md
+++ b/content/messaging/roadmap/index.md
@@ -8,7 +8,7 @@ date: 2025-12-10
 Logos Messaging is working towards these features, required to be implemented for Mainnet:
 
 - Delivery module for Logos Core
-	- Exposes [Messaging API](2025-messaging-api)
+	- Exposes [Messaging API](messaging_sdk)
 	- Exposes [Reliable Channel API](reliable_channel)
 	- Supports RLN membership on Logos Blockchain
 - Chat module for Logos Core

--- a/content/messaging/roadmap/milestones/2026-initial-integration-to-logos-core.md
+++ b/content/messaging/roadmap/milestones/2026-initial-integration-to-logos-core.md
@@ -2,7 +2,7 @@
 title: Initial Integration to Logos Core
 tags:
   - messaging-milestone
-date: 19-01-2026
+date: 2026-01-19
 github: https://github.com/logos-messaging/pm/issues/398
 ---
 

--- a/content/messaging/roadmap/milestones/2026-messaging-api-general-availability.md
+++ b/content/messaging/roadmap/milestones/2026-messaging-api-general-availability.md
@@ -101,7 +101,7 @@ Behind the MessagingAPI, Mix discovery should be started when needed and Mix pro
 
 **Dependency**: mix interface from AnonComms team must be available.
 
-**Done when**: Messages sent through the Messaging API are routed over the mix network by default, with no application changes required.
+**Done when**: All three anonymity modes work as specified, and mix routing requires no application changes beyond setting the parameter.
 
 ### [Provide documentation on the Messaging API](https://github.com/logos-messaging/pm/issues/434)
 

--- a/content/messaging/roadmap/milestones/2026-nimble-migration.md
+++ b/content/messaging/roadmap/milestones/2026-nimble-migration.md
@@ -33,7 +33,7 @@ Note: `libchat` is a Rust library and does not use Nimble.
 - CI/CD updated accordingly
 - Nix flake integration with Nimble
 
-This milestone can be removed is [[2026-chat-developer-preview# Remove unnecessary Nim shim from Logos Chat]] succeeds.  
+This milestone can be removed if [[2026-chat-developer-preview# Remove unnecessary Nim shim from Logos Chat]] succeeds.  
 
 ### [Migrate nim-sds to Nimble](https://github.com/logos-messaging/pm/issues/378)
 

--- a/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
+++ b/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
@@ -25,7 +25,7 @@ Also deprecates store hash queries as they enable linkability of participants in
 
 | Risk                                                             | (Accept, Own, Mitigation)                                                                                                                                                        |
 | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Reed-Solomon reconstruction in segementation  might be reduntant | Reed-Solomon-based reconstruction in Segmentation might be redundant, because SDS-R already ensures re-transmission of messages. Consider removing, discuss with AnonComms team. |
+| Reed-Solomon reconstruction in segmentation might be redundant | Reed-Solomon-based reconstruction in Segmentation might be redundant, because SDS-R already ensures re-transmission of messages. Consider removing, discuss with AnonComms team. |
 | Rate limit UX impact                                             | Rate limiting will cause messages to be queued or dropped. UX implications need to be communicated to Chat team and developers.                                                  |
 
 ## Deliverables

--- a/content/messaging/roadmap/milestones/2026-rln-for-edge-nodes.md
+++ b/content/messaging/roadmap/milestones/2026-rln-for-edge-nodes.md
@@ -29,7 +29,7 @@ Enable light clients with their own RLN membership to generate proofs client-sid
 
 This decouples lightpush from service node quota entirely for clients that have their own membership, and is the long-term path to sustainable edge mode.
 
-**Done when**: A light client with its own RLN membership can send a pre-proven message via lighpush, and the service node relays it without consuming its own nonce.
+**Done when**: A light client with its own RLN membership can send a pre-proven message via lightpush, and the service node relays it without consuming its own nonce.
 
 Note that this might already be possible in `logos-delivery`, in that case it needs verification.
 

--- a/content/messaging/roadmap/milestones/2026-status-logos-chat-integration.md
+++ b/content/messaging/roadmap/milestones/2026-status-logos-chat-integration.md
@@ -79,4 +79,4 @@ Status switches from its current chat protocol implementation to Logos Chat, con
 **Owner:** Delivery Team
 
 - RLN contracts are deployed on Status Network
-- Logos Delivery in Status is uses RLN on Status Network
+- Logos Delivery in Status uses RLN on Status Network


### PR DESCRIPTION
Mechanical cleanup of the last items from the full messaging-roadmap review:

- Typos: `lighpush` → `lightpush` (RLN for Edge Nodes), `segementation … reduntant` risk cell (RC — Beta), "Status is uses RLN" (Status: Logos Chat Integration), "can be removed is" → "if" (Nimble Migration)
- `date: 19-01-2026` → `2026-01-19` (Initial Integration to Logos Core)
- Index intro's dead `2025-messaging-api` link now points at the Messaging API FURPS (`messaging_sdk`)
- Messaging API — GA: Mix "Done when" no longer says "by default" — aligned with the Required/Preferred/None anonymity parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)