### PR TITLE
docs(messaging): link milestone deliverables to GitHub issues

### DIFF
--- a/content/messaging/roadmap/milestones/2026-chat-developer-preview.md
+++ b/content/messaging/roadmap/milestones/2026-chat-developer-preview.md
@@ -53,7 +53,7 @@ Group chat features will be limited at this stage and extended with further mile
 
 Installation-related FURPS (F1, F2, F5, F6, +PRIV2) moved to [Installation management](2026-chat-beta#installation-management) in Chat — Beta.
 
-### Implement simple identity model
+### [Implement simple identity model](https://github.com/logos-messaging/pm/issues/465)
 
 **Owner**: Chat Team
 
@@ -61,7 +61,7 @@ Installation-related FURPS (F1, F2, F5, F6, +PRIV2) moved to [Installation manag
 - Basic association between installations belonging to the same user
 - Basic key rotation: ability to add/remove installations
 
-### Implement contact discovery
+### [Implement contact discovery](https://github.com/logos-messaging/pm/issues/466)
 
 **Owner**: Chat Team
 
@@ -70,7 +70,7 @@ Current agreement is to use on-chain storage.
 
 > [!WARNING] Risk
 > Requires research into whether Logos Blockchain supports the needed functionality by this timeline. Fallback is to continue with out-of-band sharing.
-### Remove unnecessary Nim shim from Logos Chat
+### [Remove unnecessary Nim shim from Logos Chat](https://github.com/logos-messaging/pm/issues/467)
 
 **Owner**: Chat Team
 

--- a/content/messaging/roadmap/milestones/2026-initial-integration-to-logos-core.md
+++ b/content/messaging/roadmap/milestones/2026-initial-integration-to-logos-core.md
@@ -35,7 +35,7 @@ A `logos.dev` fleet is deployed for testnet operations.
 
 ## Deliverables
 
-### Implement a Chat module for Logos Core
+### [Implement a Chat module for Logos Core](https://github.com/logos-messaging/pm/issues/373)
 
 **Owner**: Chat Team
 
@@ -47,7 +47,7 @@ A `logos.dev` fleet is deployed for testnet operations.
 - RLN is ignored/disabled.
 - Developer-facing documentation: API reference, getting started guide, and example application walkthrough.
 
-### Implement a Delivery module for Logos Core
+### [Implement a Delivery module for Logos Core](https://github.com/logos-messaging/pm/issues/374)
 
 https://github.com/logos-messaging/pm/issues/374
 
@@ -59,7 +59,7 @@ https://github.com/logos-messaging/pm/issues/374
 - Logos Delivery module exposes API for running a Delivery Node.
 - Developer-facing documentation: API reference, getting started guide, and example application walkthrough.
 
-### Deploy required fleets for Testnet
+### [Deploy required fleets for Testnet](https://github.com/logos-messaging/pm/issues/386)
 
 **Owner**: Delivery Team
 

--- a/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-2.md
+++ b/content/messaging/roadmap/milestones/2026-logos-core-integration-phase-2.md
@@ -34,7 +34,7 @@ Integration tests are defined by the Messaging team and implemented by IFT-TS.
 
 ## Deliverables
 
-### Integrate Chat and Delivery Logos Core modules
+### [Integrate Chat and Delivery Logos Core modules](https://github.com/logos-messaging/pm/issues/387)
 
 **Owner**: Chat Team
 
@@ -56,13 +56,13 @@ Chat should be prepared to use Messaging API first, and switch to Reliable Chann
 
 The Chat module API is extended to expose group chat functionality (create group, send group message, manage members) and identity (manage installations).
 
-### Add Reliable Channel API to Logos Core Delivery module
+### [Add Reliable Channel API to Logos Core Delivery module](https://github.com/logos-messaging/pm/issues/388)
 
 **Owner**: Delivery Team
 
 When the [Reliable Channel API — Developer Preview](2026-reliable-channel-api-developer-preview.md) is ready, the Delivery Logos Core module is updated to expose it alongside the Messaging API. Chat module switches to using Reliable Channel API for message delivery.
 
-### Build Logos Core demo app in QML
+### [Build Logos Core demo app in QML](https://github.com/logos-messaging/pm/issues/390)
 
 **Owner**: Chat Team
 
@@ -71,7 +71,7 @@ A single Logos Core application implemented in QML (replacing the v0.1 Qt widget
 - Supports identity (user with multiple installations, add/remove devices)
 - Uses the Chat and Delivery Logos Core modules through their APIs
 
-### Implement integration tests for Messaging modules
+### [Implement integration tests for Messaging modules](https://github.com/logos-messaging/pm/issues/391)
 
 **Owner**: Messaging Team (definition) + IFT-TS (implementation)
 

--- a/content/messaging/roadmap/milestones/2026-nimble-migration.md
+++ b/content/messaging/roadmap/milestones/2026-nimble-migration.md
@@ -9,11 +9,10 @@ github: https://github.com/logos-messaging/pm/issues/400
 
 **Resources Required**:
 - 1 Delivery engineer (intermittent)
-- 1 Chat engineer (intermittent)
 
 Migrate all main Logos Messaging Nim repositories from the `nimbus-build-system` to Nimble package manager. This simplifies dependency management, improves IDE integration and aligns with the broader Logos ecosystem tooling.
 
-Note: `libchat` is a Rust library and does not use Nimble.
+Note: `logos-chat` (including `libchat`) is pure Rust and does not use Nimble — see [Remove unnecessary Nim shim from Logos Chat](2026-chat-developer-preview#remove-unnecessary-nim-shim-from-logos-chat).
 
 ## Deliverables
 
@@ -24,16 +23,6 @@ Note: `libchat` is a Rust library and does not use Nimble.
 - `logos-messaging/logos-delivery` uses Nimble for build and dependency management
 - CI/CD updated accordingly
 - Nix flake integration with Nimble
-
-### [Migrate logos-chat to Nimble](https://github.com/logos-messaging/logos-chat/issues/31)
-
-**Owner**: Chat Team
-
-- `logos-messaging/logos-chat` uses Nimble for build and dependency management
-- CI/CD updated accordingly
-- Nix flake integration with Nimble
-
-This milestone can be removed if [[2026-chat-developer-preview# Remove unnecessary Nim shim from Logos Chat]] succeeds.  
 
 ### [Migrate nim-sds to Nimble](https://github.com/logos-messaging/pm/issues/378)
 

--- a/content/messaging/roadmap/milestones/2026-nimble-migration.md
+++ b/content/messaging/roadmap/milestones/2026-nimble-migration.md
@@ -25,7 +25,7 @@ Note: `libchat` is a Rust library and does not use Nimble.
 - CI/CD updated accordingly
 - Nix flake integration with Nimble
 
-### Migrate logos-chat to Nimble
+### [Migrate logos-chat to Nimble](https://github.com/logos-messaging/logos-chat/issues/31)
 
 **Owner**: Chat Team
 

--- a/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
+++ b/content/messaging/roadmap/milestones/2026-reliable-channel-api-beta.md
@@ -30,7 +30,7 @@ Also deprecates store hash queries as they enable linkability of participants in
 
 ## Deliverables
 
-### Create Segmentation Library
+### [Create Segmentation Library](https://github.com/logos-messaging/pm/issues/318)
 
 https://github.com/logos-messaging/pm/issues/318
 

--- a/content/messaging/roadmap/milestones/2026-reliable-channel-api-developer-preview.md
+++ b/content/messaging/roadmap/milestones/2026-reliable-channel-api-developer-preview.md
@@ -32,7 +32,7 @@ This milestone focuses on forming the API and delivering a pre-configured SDS ex
 
 ## Deliverables
 
-### Deliver Reliable Channel API
+### [Deliver Reliable Channel API](https://github.com/logos-messaging/pm/issues/412)
 
 **Owner**: Delivery Team
 
@@ -54,7 +54,7 @@ This milestone focuses on forming the API and delivering a pre-configured SDS ex
 
 Note: No segmentation or rate limit manager in this milestone. SDS messages cached locally.
 
-### Implement SDS Repair
+### [Implement SDS Repair](https://github.com/logos-messaging/pm/issues/413)
 
 **Owner**: Delivery Team
 


### PR DESCRIPTION
## Summary

Audited every milestone listed in the [messaging roadmap index](https://roadmap.logos.co/messaging/roadmap/) and its deliverables, ensuring each links to the corresponding GitHub issue in `logos-messaging/pm`.

**Milestones:** all 23 index-listed milestone files already have a valid `github:` frontmatter link, verified to resolve to a matching pm milestone issue. ✅

**Deliverables:** added missing issue links to 14 deliverable headings (matched via `sub_issues` of the parent pm milestone issue):

| Milestone | Deliverable | Issue |
|---|---|---|
| Initial Integration to Logos Core (pm#398) | Implement a Chat module for Logos Core | pm#373 |
| | Implement a Delivery module for Logos Core | pm#374 |
| | Deploy required fleets for Testnet | pm#386 |
| Reliable Channel API — Developer Preview (pm#405) | Deliver Reliable Channel API | pm#412 |
| | Implement SDS Repair | pm#413 |
| Chat — Developer Preview (pm#406) | Implement simple identity model | pm#465 *(new)* |
| | Implement contact discovery | pm#466 *(new)* |
| | Remove unnecessary Nim shim from Logos Chat | pm#467 *(new)* |
| Logos Core Integration — Phase 2 (pm#397) | Integrate Chat and Delivery Logos Core modules | pm#387 |
| | Add Reliable Channel API to Logos Core Delivery module | pm#388 |
| | Build Logos Core demo app in QML | pm#390 |
| | Implement integration tests for Messaging modules | pm#391 |
| Reliable Channel API — Beta (pm#402) | Create Segmentation Library | pm#318 |

pm#465–#467 were created retroactively as sub-issues of the closed pm#406 milestone and closed as completed.

**Removed:** the *Migrate logos-chat to Nimble* deliverable from the Nimble Migration milestone — `logos-chat` is pure Rust after the Nim shim removal (pm#467), so the migration no longer applies. The milestone note and resource list were updated accordingly.

## Notes

- **Reliable Channel API — Beta:** *Add Segmentation to Reliable Channel API* and *Support different encryption for sync messages* link to `logos-delivery#3854`/`#3856` — legitimate cross-repo sub-issues of pm#402, left as-is.
- `logos-chat#31` (Migrate to nimble) is still open and can likely be closed as not planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)