### PR TITLE
fix: preserve HTML asset extensions in Quartz 5

### DIFF
--- a/quartz/plugins/emitters/assets.ts
+++ b/quartz/plugins/emitters/assets.ts
@@ -27,10 +27,24 @@ const filesToCopy = async (argv: Argv, cfg: QuartzConfig, excludeExtensions: Set
   return await glob("**", argv.directory, excludePatterns)
 }
 
+export const assetOutputPath = (fp: FilePath): FilePath => {
+  const name = slugifyFilePath(fp)
+  const sourceExtension = path.extname(fp)
+
+  // slugifyFilePath intentionally removes HTML extensions for page slugs.
+  // Assets are copied verbatim, so retain an extension that slugification removed
+  // to ensure static servers send the correct content type.
+  if (sourceExtension !== "" && path.extname(name) === "") {
+    return `${name}${sourceExtension}` as FilePath
+  }
+
+  return name as unknown as FilePath
+}
+
 const copyFile = async (argv: Argv, fp: FilePath) => {
   const src = joinSegments(argv.directory, fp) as FilePath
 
-  const name = slugifyFilePath(fp)
+  const name = assetOutputPath(fp)
   const dest = joinSegments(argv.output, name) as FilePath
 
   const dir = path.dirname(dest) as FilePath


### PR DESCRIPTION
## Summary

Fixes standalone weekly HTML reports (ex https://roadmap.logos.co/reports/weekly/2026-07-13) being displayed as source code after the Quartz 5 migration.

Quartz 5 removed the `.html` extension when copying these assets, causing the server to return them without an HTML content type. This restores the extension while preserving clean URLs.
