### PR TITLE
Blockchain weekly updates: 2026-07-13 through 2026-08-03

### DIFF
--- a/content/blockchain/updates/2026-07-13.md
+++ b/content/blockchain/updates/2026-07-13.md
@@ -1,0 +1,98 @@
+---
+title: 2026-07-13 Logos Blockchain weekly
+tags:
+  - nomos-updates
+date: 2026-07-13
+lastmod: 2026-07-13
+draft: false
+description: Weekly update of Logos Blockchain
+---
+
+# Logos Blockchain Weekly Update - 2026-07-13
+
+## `blockchain:highlights`
+
+- **Tokenomics enabled on master**: transaction fees end-to-end [#3070](https://github.com/logos-blockchain/logos-blockchain/pull/3070), fund endpoint [#3100](https://github.com/logos-blockchain/logos-blockchain/pull/3100), non-zero-gas tests [#3083](https://github.com/logos-blockchain/logos-blockchain/pull/3083)
+- **Scalable Initial Block Download merged**: requests fan out across discovered peers [#3019](https://github.com/logos-blockchain/logos-blockchain/pull/3019)
+- **Channel operations merged in Nimbos** [nimbos#100](https://github.com/logos-co/nimbos/pull/100)
+- **Proof of Leadership post-quantum proving findings published** [doc](https://app.notion.com/p/nomos-tech/PoL-Post-Quantum-Proving-Findings-Summary-37a261aa09df80fa956efb071ab26ad6)
+    
+## `blockchain:bedrock:research`
+
+- `blockchain:bedrock:research:post-quantum`
+  - Proof of Leadership post-quantum proving findings summary published, based on the cross-scheme benchmark results [doc](https://app.notion.com/p/nomos-tech/PoL-Post-Quantum-Proving-Findings-Summary-37a261aa09df80fa956efb071ab26ad6)
+  - Post-quantum primitive benchmark dashboard published [dashboard](https://megonen.github.io/pq-benchmark/)
+
+- `blockchain:bedrock:research:mantle`
+  - Multiple Ed25519 threshold verification factored out of the Mantle spec, with configuration-threshold validation added [logos-lips#367](https://github.com/logos-co/logos-lips/pull/367)
+  - SDP Per-Service Uniqueness RFC opened: `provider_id` and `zk_id` unique within a service (in-review) [logos-lips#371](https://github.com/logos-co/logos-lips/pull/371)
+
+- `blockchain:bedrock:research:total-stake-inference`
+  - "Referenced-Block Visibility for Total Stake Inference" report restructured with an explicit inference-feedback evaluation layer and comparisons among known-stake, chain-only, and reference-enhanced inference; references substantially improve denominator calibration and reduce chain-only over-emission and fork waste [doc](https://app.notion.com/p/nomos-tech/Referenced-Block-Visibility-for-Total-Stake-Inference-36a261aa09df8119940dd25205b12f85)
+  - New network-delays model implemented and tested in Python, with a new results section added to the report [doc](https://app.notion.com/p/nomos-tech/Referenced-Block-Visibility-for-Total-Stake-Inference-36a261aa09df8119940dd25205b12f85#398261aa09df80a0b828ff7be5b8599d)
+
+- `blockchain:bedrock:research:cross-zone-sequencing`
+  - Costly Abort Mechanism drafted: on-chain bond protocol steps (deposit timing, on-chain lock window, fund recovery under normal completion and abort), plus a survey of timed-lock puzzles and timed commitments for penalizing non-responsive parties in the off-chain protocol [doc](https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-396261aa09df80f99b7ffcd6ed76e0aa)
+
+- `blockchain:bedrock:research:anonymous-communications`
+  - Single-path mix model specified end to end, with a sender-set stake estimator and closed-form latency and bandwidth overheads validated against the simulator [doc](https://app.notion.com/p/nomos-tech/Single-Path-Mix-Model-Sender-Set-Stake-Estimator-Trilemma-Costs-53b261aa09df822ead6981a859eb70ff)
+
+## `blockchain:bedrock:eng`
+
+- `blockchain:bedrock:eng:blend`
+  - Blend message wire encoding fixed to avoid dynamically sized types [#3105](https://github.com/logos-blockchain/logos-blockchain/pull/3105)
+
+- `blockchain:bedrock:eng:security-audit`
+  - `NomEncode`/`NomDecode` migration continued: `CryptarchiaParameter` [#3082](https://github.com/logos-blockchain/logos-blockchain/pull/3082) and `MantleTx` [#3103](https://github.com/logos-blockchain/logos-blockchain/pull/3103) merged; unified `WireEncode`/`WireDecode` traits in a new `logos-blockchain-wire` crate (WIP, draft) [#3119](https://github.com/logos-blockchain/logos-blockchain/pull/3119)
+  - `Bounded` wrapper introduced for size-validated types, with `String` and `Multiaddr` aliases [#3093](https://github.com/logos-blockchain/logos-blockchain/pull/3093); bounded size and transaction count enforced for blocks [#3068](https://github.com/logos-blockchain/logos-blockchain/pull/3068)
+
+- `blockchain:bedrock:eng:node`
+  - Scalable Initial Block Download merged: requests fan out across discovered peers [#3019](https://github.com/logos-blockchain/logos-blockchain/pull/3019)
+  - Tokenomics enabled on master with genesis gas prices set to 1 [#3070](https://github.com/logos-blockchain/logos-blockchain/pull/3070)
+  - Merged from last week's in-review set: mempool transaction receive order [#3053](https://github.com/logos-blockchain/logos-blockchain/pull/3053), wallet pending-note reservation [#3080](https://github.com/logos-blockchain/logos-blockchain/pull/3080), KMS error propagation [#3073](https://github.com/logos-blockchain/logos-blockchain/pull/3073), C bindings shutdown fix [#3075](https://github.com/logos-blockchain/logos-blockchain/pull/3075)
+  - Current gas prices exposed over HTTP [#3088](https://github.com/logos-blockchain/logos-blockchain/pull/3088); faucet drips serialized through a queue with per-key cooldown [#3092](https://github.com/logos-blockchain/logos-blockchain/pull/3092)
+  - Fee market test suite with end-to-end price rise/recovery scenarios (in-review) [#3111](https://github.com/logos-blockchain/logos-blockchain/pull/3111); channel thresholds accounted for in gas costs (in-review) [#3118](https://github.com/logos-blockchain/logos-blockchain/pull/3118)
+
+- `blockchain:bedrock:eng:testing`
+  - End-to-end tests fixed for non-zero gas prices [#3083](https://github.com/logos-blockchain/logos-blockchain/pull/3083); atomic wallet scanner test added [#3101](https://github.com/logos-blockchain/logos-blockchain/pull/3101); e2e and cucumber suites split [#3120](https://github.com/logos-blockchain/logos-blockchain/pull/3120)
+
+- `blockchain:bedrock:eng:zone-sdk`
+  - `MantleTxContext` extracted from `MantleTxBuilder` merged, a first step toward Tokenomics support in the zone SDK [#3081](https://github.com/logos-blockchain/logos-blockchain/pull/3081)
+  - Tokenomics wiring: transaction fund endpoint [#3100](https://github.com/logos-blockchain/logos-blockchain/pull/3100) with C bindings [#3104](https://github.com/logos-blockchain/logos-blockchain/pull/3104), non-zero gas prices enabled in the zone SDK [#3109](https://github.com/logos-blockchain/logos-blockchain/pull/3109); priority tip on the fund endpoint to buffer transaction resubmission (in-review) [#3116](https://github.com/logos-blockchain/logos-blockchain/pull/3116)
+  - Pending set unified with the channel view [#3113](https://github.com/logos-blockchain/logos-blockchain/pull/3113); channel-update transactions unified with custom transactions (in-review) [#3122](https://github.com/logos-blockchain/logos-blockchain/pull/3122)
+
+- `blockchain:bedrock:eng:logos-core`
+  - Deployments now use Logos Core as the init node [#3084](https://github.com/logos-blockchain/logos-blockchain/pull/3084)
+  - External testnet nodes can send metrics to testnet.blockchain.logos.co: OTLP HTTP exporter in the tracing crate [#3096](https://github.com/logos-blockchain/logos-blockchain/pull/3096), `/otlp` endpoint exposed [#3098](https://github.com/logos-blockchain/logos-blockchain/pull/3098)
+  - Grafana data persists across deployments [#3090](https://github.com/logos-blockchain/logos-blockchain/pull/3090); cfgsync removed from deployments [#3099](https://github.com/logos-blockchain/logos-blockchain/pull/3099)
+  - Blend join fixed over FFI with regression fixes [#3121](https://github.com/logos-blockchain/logos-blockchain/pull/3121); module update (in-review) [logos-blockchain-module#53](https://github.com/logos-blockchain/logos-blockchain-module/pull/53); explorer tab with copyable fields in the dashboard UI (in-review) [logos-blockchain-ui#33](https://github.com/logos-blockchain/logos-blockchain-ui/pull/33)
+  - Module migration guide from 0.1.2 to 0.2.0 published [doc](https://nomos-tech.notion.site/Blockchain-Module-Journey-37c261aa09df80f7bbc4e13bb9a60201)
+
+## `blockchain:logos-execution-zone`
+
+- `blockchain:logos-execution-zone:cross-zone`
+  - Async cross-zone messaging merged, including the browser demo with live send/finalize/receive timings [#542](https://github.com/logos-blockchain/logos-execution-zone/pull/542)
+
+- `blockchain:logos-execution-zone:accounts`
+  - Viewing key and ciphertext binding merged [#550](https://github.com/logos-blockchain/logos-execution-zone/pull/550)
+
+- `blockchain:logos-execution-zone:wallet-ui`
+  - Wallet deploy command now waits for transaction inclusion in a block [#587](https://github.com/logos-blockchain/logos-execution-zone/pull/587)
+  - PDA account-id generation in the wallet FFI (in-review) [#582](https://github.com/logos-blockchain/logos-execution-zone/pull/582); batched merkle proof fetching (in-review) [#598](https://github.com/logos-blockchain/logos-execution-zone/pull/598)
+  - Multi-sequencer wallet client opened (in-review) [#600](https://github.com/logos-blockchain/logos-execution-zone/pull/600)
+  - Account labels functionality merged in the LEZ module [logos-execution-zone-module#41](https://github.com/logos-blockchain/logos-execution-zone-module/pull/41)
+
+- `blockchain:logos-execution-zone:sequencer`
+  - Sequencer state bootstrap from Bedrock (in-review) [#606](https://github.com/logos-blockchain/logos-execution-zone/pull/606)
+  - Common two-tip chain state for decentralized sequencing (in-review) [#603](https://github.com/logos-blockchain/logos-execution-zone/pull/603)
+
+- `blockchain:logos-execution-zone:explorer`
+  - Indexer recovers from invalid blocks [#581](https://github.com/logos-blockchain/logos-execution-zone/pull/581); initial indexer breakpoint fix preparation [#607](https://github.com/logos-blockchain/logos-execution-zone/pull/607)
+
+- `blockchain:logos-execution-zone:refactor`
+  - Integration tests start the sequencer from prebuilt blocks [#590](https://github.com/logos-blockchain/logos-execution-zone/pull/590); missed mutants addressed in the bridge guard [#609](https://github.com/logos-blockchain/logos-execution-zone/pull/609)
+
+## `nimbos`
+
+- Channel operations merged: `channel_state`, `mantle_state`, and ledger tests [nimbos#100](https://github.com/logos-co/nimbos/pull/100)
+- Proof of Claim Groth16 verifier with shared verification-key helpers and circuit/fixture tests (in-review) [nimbos#120](https://github.com/logos-co/nimbos/pull/120)

--- a/content/blockchain/updates/2026-07-13.md
+++ b/content/blockchain/updates/2026-07-13.md
@@ -12,7 +12,7 @@ description: Weekly update of Logos Blockchain
 
 ## `blockchain:highlights`
 
-- **Tokenomics enabled on master**: transaction fees end-to-end [#3070](https://github.com/logos-blockchain/logos-blockchain/pull/3070), fund endpoint [#3100](https://github.com/logos-blockchain/logos-blockchain/pull/3100), non-zero-gas tests [#3083](https://github.com/logos-blockchain/logos-blockchain/pull/3083)
+- **Tokenomics enabled on master (baselayer only)**: transaction fees end-to-end [#3070](https://github.com/logos-blockchain/logos-blockchain/pull/3070), fund endpoint [#3100](https://github.com/logos-blockchain/logos-blockchain/pull/3100), non-zero-gas tests [#3083](https://github.com/logos-blockchain/logos-blockchain/pull/3083)
 - **Scalable Initial Block Download merged**: requests fan out across discovered peers [#3019](https://github.com/logos-blockchain/logos-blockchain/pull/3019)
 - **Channel operations merged in Nimbos** [nimbos#100](https://github.com/logos-co/nimbos/pull/100)
 - **Proof of Leadership post-quantum proving findings published** [doc](https://app.notion.com/p/nomos-tech/PoL-Post-Quantum-Proving-Findings-Summary-37a261aa09df80fa956efb071ab26ad6)
@@ -48,7 +48,7 @@ description: Weekly update of Logos Blockchain
 
 - `blockchain:bedrock:eng:node`
   - Scalable Initial Block Download merged: requests fan out across discovered peers [#3019](https://github.com/logos-blockchain/logos-blockchain/pull/3019)
-  - Tokenomics enabled on master with genesis gas prices set to 1 [#3070](https://github.com/logos-blockchain/logos-blockchain/pull/3070)
+  - Tokenomics enabled on master, baselayer only, with genesis gas prices set to 1 [#3070](https://github.com/logos-blockchain/logos-blockchain/pull/3070)
   - Merged from last week's in-review set: mempool transaction receive order [#3053](https://github.com/logos-blockchain/logos-blockchain/pull/3053), wallet pending-note reservation [#3080](https://github.com/logos-blockchain/logos-blockchain/pull/3080), KMS error propagation [#3073](https://github.com/logos-blockchain/logos-blockchain/pull/3073), C bindings shutdown fix [#3075](https://github.com/logos-blockchain/logos-blockchain/pull/3075)
   - Current gas prices exposed over HTTP [#3088](https://github.com/logos-blockchain/logos-blockchain/pull/3088); faucet drips serialized through a queue with per-key cooldown [#3092](https://github.com/logos-blockchain/logos-blockchain/pull/3092)
   - Fee market test suite with end-to-end price rise/recovery scenarios (in-review) [#3111](https://github.com/logos-blockchain/logos-blockchain/pull/3111); channel thresholds accounted for in gas costs (in-review) [#3118](https://github.com/logos-blockchain/logos-blockchain/pull/3118)

--- a/content/blockchain/updates/2026-07-20.md
+++ b/content/blockchain/updates/2026-07-20.md
@@ -1,0 +1,96 @@
+---
+title: 2026-07-20 Logos Blockchain weekly
+tags:
+  - nomos-updates
+date: 2026-07-20
+lastmod: 2026-07-20
+draft: false
+description: Weekly update of Logos Blockchain
+---
+
+# Logos Blockchain Weekly Update - 2026-07-20
+
+## `blockchain:highlights`
+
+- **SDP validator operations merged in Nimbos** [nimbos#111](https://github.com/logos-co/nimbos/pull/111); **Proof of Claim verifier merged** [nimbos#120](https://github.com/logos-co/nimbos/pull/120)
+- **Multi-sequencer committee support with convergence demo** [logos-execution-zone#616](https://github.com/logos-blockchain/logos-execution-zone/pull/616)
+- **Channel Participation in Proof of Stake finalized**: spec [logos-lips#364](https://github.com/logos-co/logos-lips/pull/364) and implementation [#3145](https://github.com/logos-blockchain/logos-blockchain/pull/3145) ready to merge
+- **Total Stake Inference feedback evaluated at mainnet parameters**: block references keep inferred stake near true stake [doc](https://app.notion.com/p/nomos-tech/Referenced-Block-Visibility-for-Total-Stake-Inference-36a261aa09df8119940dd25205b12f85)
+
+## `blockchain:bedrock:research`
+
+- `blockchain:bedrock:research:mantle`
+  - SDP Per-Service Uniqueness RFC merged: `provider_id` and `zk_id` unique within a service [logos-lips#371](https://github.com/logos-co/logos-lips/pull/371)
+
+- `blockchain:bedrock:research:cryptarchia`
+  - Channel Participation in Proof of Stake finished the research phase: RFC ready to merge [logos-lips#364](https://github.com/logos-co/logos-lips/pull/364), implementation accepted (in-review) [#3145](https://github.com/logos-blockchain/logos-blockchain/pull/3145)
+
+- `blockchain:bedrock:research:total-stake-inference`
+  - Mainnet-parameter inference-feedback evaluation completed (T=388800 slots, f=1/30): block references keep the inferred denominator substantially closer to true stake; at delays 10/20/29, 0.959/0.882/0.759 of true stake versus 0.705/0.399/0.168 chain-only; at delay 40, chain-only falls to ~0.101 while referenced configurations reach up to ~0.986 [doc](https://app.notion.com/p/nomos-tech/Referenced-Block-Visibility-for-Total-Stake-Inference-36a261aa09df8119940dd25205b12f85)
+  - Additional simulations and figures added to the "Modelling of Network Delays" document [doc](https://app.notion.com/p/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0)
+
+- `blockchain:bedrock:research:permissionless-channel-sequencing`
+  - Pivot to fully permissionless sequencing: Proposal VIII adopts a public per-channel lottery (new L1 op family, no committee), with a decision map and first-pass withdrawal-exit simulations covering exit-family comparison, lottery weight during pending exits, and concentration windows [doc](https://app.notion.com/p/nomos-tech/Permissionless-Channel-Sequencing-Proposal-VIII-3a3261aa09df80168767c7f715fa4f52)
+
+- `blockchain:bedrock:research:cross-zone-sequencing`
+  - Abort Attribution reworked into a commitment-only + challenge-response design following the optimistic fair exchange principle: the happy path registers only hash commitments on-chain, with content disclosed on-chain only when a challenge is opened [doc](https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-396261aa09df80f99b7ffcd6ed76e0aa#39d261aa09df8098af6fc62d8b40a8bc)
+  - Intent structure and hash computation fixed: canonical `CrossZoneIntent` serialization with SHA-256 commitments, so `proposal_id = H(intent)` serves as an openable commitment in disputes [doc](https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-396261aa09df80f99b7ffcd6ed76e0aa#39d261aa09df8098af6fc62d8b40a8bc)
+
+- `blockchain:bedrock:research:anonymous-communications`
+  - Bayesian sender-attribution attack built, completing the anonymity axis alongside stake inference, with three unlinkability measures: top-1 de-anonymisation, mean true-sender posterior, and posterior entropy [doc](https://app.notion.com/p/nomos-tech/Bayesian-sender-attribution-attack-trilemma-and-the-experimental-framework-with-the-single-path-mi-87e261aa09df838e80bb01eb6f358bb1), [doc](https://app.notion.com/p/nomos-tech/Bayesian-Sender-Attribution-Attack-and-the-Three-Unlinkability-Measures-3a6261aa09df80f5a465ee7461021082)
+
+## `blockchain:bedrock:eng`
+
+- `blockchain:bedrock:eng:blend`
+  - Connectivity maintenance design rewritten for simplicity (WIP) [doc](https://app.notion.com/p/nomos-tech/WIP-Connectivity-Maintenance-readable-rewrite-107d88825f9f4d19beffafbaaa69ba86)
+
+- `blockchain:bedrock:eng:node`
+  - Initial Block Download fix: `AlreadyApplied` errors ignored to handle the overlapped part of the chain [#3126](https://github.com/logos-blockchain/logos-blockchain/pull/3126)
+  - Devnet validation completed: Initial Block Download, SDP no-garbage-collection behavior, service rewards distribution, and Tokenomics fees confirmed working as intended
+  - Channel thresholds accounted for in gas costs merged [#3118](https://github.com/logos-blockchain/logos-blockchain/pull/3118); priority tip on the fund endpoint merged [#3116](https://github.com/logos-blockchain/logos-blockchain/pull/3116)
+  - SDP snapshot API endpoint added [#3132](https://github.com/logos-blockchain/logos-blockchain/pull/3132); SDP declarations returned keyed by id [#3133](https://github.com/logos-blockchain/logos-blockchain/pull/3133); `discovered_peers` on `/network/info` (in-review) [#3135](https://github.com/logos-blockchain/logos-blockchain/pull/3135)
+  - Recovery state moving to RocksDB (in-review): Overwatch runtime handle for state operators [Overwatch#142](https://github.com/logos-co/Overwatch/pull/142), node recovery state [#3134](https://github.com/logos-blockchain/logos-blockchain/pull/3134)
+
+- `blockchain:bedrock:eng:testing`
+  - Testing Framework merged: snapshot store support [logos-blockchain-testing#56](https://github.com/logos-blockchain/logos-blockchain-testing/pull/56), multiple apps in one test stack [#57](https://github.com/logos-blockchain/logos-blockchain-testing/pull/57), unified cluster provisioning for scenarios, app deployments, and manual clusters [#58](https://github.com/logos-blockchain/logos-blockchain-testing/pull/58)
+  - Tokio-console profiling: cucumber integration [#3129](https://github.com/logos-blockchain/logos-blockchain/pull/3129) and console-subscriber update [#3136](https://github.com/logos-blockchain/logos-blockchain/pull/3136) merged, opt-in task naming in Overwatch [Overwatch#141](https://github.com/logos-co/Overwatch/pull/141); Overwatch bump for tokio-console (in-review) [#3148](https://github.com/logos-blockchain/logos-blockchain/pull/3148)
+
+- `blockchain:bedrock:eng:zone-sdk`
+  - Channel-update transactions unified with custom transactions merged [#3122](https://github.com/logos-blockchain/logos-blockchain/pull/3122)
+  - L1 op identity and finalized slot surfaced on channel messages (in-review) [#3147](https://github.com/logos-blockchain/logos-blockchain/pull/3147)
+
+- `blockchain:bedrock:eng:logos-core`
+  - Node 0.2.1-rc.2 pre-release published [release](https://github.com/logos-blockchain/logos-blockchain/releases/tag/0.2.1-rc.2), with module release steps added to the release checklist [#3112](https://github.com/logos-blockchain/logos-blockchain/pull/3112)
+  - Module join-blend fix merged [logos-blockchain-module#53](https://github.com/logos-blockchain/logos-blockchain-module/pull/53); explorer tab with copyable fields merged in the dashboard UI [logos-blockchain-ui#33](https://github.com/logos-blockchain/logos-blockchain-ui/pull/33)
+
+## `blockchain:logos-execution-zone`
+
+- `blockchain:logos-execution-zone:wallet-ui`
+  - Wallet synchronization flow rework merged [#585](https://github.com/logos-blockchain/logos-execution-zone/pull/585)
+  - PDA account-id generation in the wallet FFI merged [#582](https://github.com/logos-blockchain/logos-execution-zone/pull/582)
+  - Batched merkle proof fetching merged [#598](https://github.com/logos-blockchain/logos-execution-zone/pull/598)
+
+- `blockchain:logos-execution-zone:sequencer`
+  - Multi-sequencer committee support merged with `adminConfigureChannel` and a convergence demo [#616](https://github.com/logos-blockchain/logos-execution-zone/pull/616)
+  - Request distribution across multiple sequencers opened (in-review) [#623](https://github.com/logos-blockchain/logos-execution-zone/pull/623)
+
+- `blockchain:logos-execution-zone:accounts`
+  - View-tag randomization for updated accounts (in-review) [#591](https://github.com/logos-blockchain/logos-execution-zone/pull/591)
+  - Dummy-note padding via random seeding of nullifiers and commitments (in-review) [#592](https://github.com/logos-blockchain/logos-execution-zone/pull/592); ciphertext padding, which closes the last large privacy leak (the ciphertext size), opened (in-review) [#630](https://github.com/logos-blockchain/logos-execution-zone/pull/630)
+
+- `blockchain:logos-execution-zone:cross-zone`
+  - Programs deployed at genesis instead of builtins (in-review) [#615](https://github.com/logos-blockchain/logos-execution-zone/pull/615)
+  - Cross-zone generalization directions written up for team decisions [doc](https://app.notion.com/p/Directions-to-agree-with-the-team-39f8f96fb65c80ada3acf18d3e16a7b2)
+
+- `blockchain:logos-execution-zone:refactor`
+  - CI sped up with a prebuilt docker image caching dependencies [#618](https://github.com/logos-blockchain/logos-execution-zone/pull/618)
+
+## `nimbos`
+
+- SDP validator operations merged: declare/withdraw/active ops wired into the ledger, with registry, query API, and tests [nimbos#111](https://github.com/logos-co/nimbos/pull/111)
+- Proof of Claim Groth16 verifier merged, with shared verification-key helpers and circuit/fixture tests [nimbos#120](https://github.com/logos-co/nimbos/pull/120)
+- SDP module layout refactored to honour layering rules [nimbos#128](https://github.com/logos-co/nimbos/pull/128)
+- Epoch state management (in-review) [nimbos#126](https://github.com/logos-co/nimbos/pull/126)
+- Anonymous Leaders Reward Protocol ledger state and claim path opened (in-review) [nimbos#134](https://github.com/logos-co/nimbos/pull/134)
+- SDP epoch snapshot mapping fixed to n+2 (in-review) [nimbos#136](https://github.com/logos-co/nimbos/pull/136); non-mutating SDP/channel state transitions via sink parameters (in-review) [nimbos#137](https://github.com/logos-co/nimbos/pull/137)
+- End-to-end Initial Block Download tested against a local Rust network

--- a/content/blockchain/updates/2026-07-27.md
+++ b/content/blockchain/updates/2026-07-27.md
@@ -1,0 +1,103 @@
+---
+title: 2026-07-27 Logos Blockchain weekly
+tags:
+  - nomos-updates
+date: 2026-07-27
+lastmod: 2026-07-27
+draft: false
+description: Weekly update of Logos Blockchain
+---
+
+# Logos Blockchain Weekly Update - 2026-07-27
+
+## `blockchain:highlights`
+
+- **Channel Participation in Proof of Stake LIP merged**: spec [logos-lips#364](https://github.com/logos-co/logos-lips/pull/364) and implementation [#3145](https://github.com/logos-blockchain/logos-blockchain/pull/3145)
+- **Post-Quantum Safety Analysis of the Bedrock layer finalized** [doc](https://app.notion.com/p/nomos-tech/Post-Quantum-Safety-Analysis-of-the-Logos-Bedrock-Layer-360261aa09df80a6a98dc4d787cfa499)
+- **Multi-sequencer support merged across the Logos Execution Zone stack**: wallet client [#600](https://github.com/logos-blockchain/logos-execution-zone/pull/600), request distribution [#623](https://github.com/logos-blockchain/logos-execution-zone/pull/623), two-tip chain state [#603](https://github.com/logos-blockchain/logos-execution-zone/pull/603), Bedrock bootstrap [#606](https://github.com/logos-blockchain/logos-execution-zone/pull/606)
+
+## `blockchain:bedrock:research`
+
+- `blockchain:bedrock:research:cryptarchia`
+  - Channel Participation in Proof of Stake merged: spec [logos-lips#364](https://github.com/logos-co/logos-lips/pull/364) and implementation [#3145](https://github.com/logos-blockchain/logos-blockchain/pull/3145)
+  - Fast Bootstrapping RFC passed the research phase [logos-lips#368](https://github.com/logos-co/logos-lips/pull/368); blake2b dynamic merkle tree opened toward its implementation (in-review) [#3174](https://github.com/logos-blockchain/logos-blockchain/pull/3174)
+
+- `blockchain:bedrock:research:post-quantum`
+  - Post-Quantum Safety Analysis of the Logos Bedrock Layer finalized [doc](https://app.notion.com/p/nomos-tech/Post-Quantum-Safety-Analysis-of-the-Logos-Bedrock-Layer-360261aa09df80a6a98dc4d787cfa499)
+  - Post-Quantum ZK Transition Paths written up from the cross-scheme benchmark results [doc](https://app.notion.com/p/nomos-tech/Post-Quantum-ZK-Transition-Paths-39c261aa09df8049872cdfc7ab1eb0e8)
+  - Benchmark implementation extended with Rust and aws-lc-rs libraries (in-review) [logos-blockchain-pocs#112](https://github.com/logos-blockchain/logos-blockchain-pocs/pull/112); benchmark dashboard updated [dashboard](https://megonen.github.io/pq-bench-rpi5/)
+
+- `blockchain:bedrock:research:total-stake-inference`
+  - "Modelling of Network Delays" [doc](https://app.notion.com/p/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0) and "Total Stake Inference with Network Delays" [doc](https://app.notion.com/p/nomos-tech/Total-Stake-Inference-with-Network-Delays-372261aa09df82188afd01720e33a79c) revised
+  - Total Stake Inference with uncle references: simulation results promising, with further runs planned to explore the parameter space and ensure equilibration [doc](https://app.notion.com/p/nomos-tech/Referenced-Block-Visibility-for-Total-Stake-Inference-36a261aa09df8119940dd25205b12f85#39c261aa09df80e1a2e2d380a5a385c7)
+
+- `blockchain:bedrock:research:permissionless-channel-sequencing`
+  - Channel lottery fully specified and made executable: reference implementation plus adversary-in-the-loop simulations covering exit-freeze end-to-end, mass-exit drain, and stall succession [doc](https://app.notion.com/p/nomos-tech/Permissionless-Channel-Sequencing-Channel-Lottery-3ab261aa09df8041928ce10c0ad15cc3)
+  - Proposal VIII revised against a survey of the academic and industry literature; substrate refreshed to Mantle v1.9.0 [doc](https://app.notion.com/p/nomos-tech/Permissionless-Channel-Sequencing-Proposal-VIII-3ab261aa09df80eea54cdcdfeb30a115)
+
+- `blockchain:bedrock:research:anonymous-communications`
+  - Single-path mix model completed under both uniform and geography-calibrated latency laws (continent mixture calibrated to real inter-city pings), with anonymity-latency-bandwidth trilemma plots [doc](https://app.notion.com/p/nomos-tech/Single-Path-Mix-Model-Complete-Uniform-Geo-the-Trilemma-Plots-c42261aa09df835d856401f5e4fa48a6)
+  - Single-path Bayesian traffic analysis completed for both latency models, extending sender attribution with the geographic latency model [doc](https://app.notion.com/p/nomos-tech/Single-Path-Mix-Model-Uniform-and-Geographic-Latency-the-Trilemma-Plots-3a9261aa09df80119d06f797e00da34e)
+
+## `blockchain:bedrock:eng`
+
+- `blockchain:bedrock:eng:security-audit`
+  - Bounded-type hardening continued: op-proof vectors [#3150](https://github.com/logos-blockchain/logos-blockchain/pull/3150), SDP declarations in the genesis block [#3157](https://github.com/logos-blockchain/logos-blockchain/pull/3157), exact-size zk verifier JSON input [#3167](https://github.com/logos-blockchain/logos-blockchain/pull/3167), block proposal references [#3170](https://github.com/logos-blockchain/logos-blockchain/pull/3170), and wallet block transformations [#3175](https://github.com/logos-blockchain/logos-blockchain/pull/3175) merged; bounded, validated merkle paths (in-review) [#3183](https://github.com/logos-blockchain/logos-blockchain/pull/3183)
+
+- `blockchain:bedrock:eng:node`
+  - Transactions revamped into a verification typestate: verification state tracked at compile time, moving operation verification out of the ledger [#3123](https://github.com/logos-blockchain/logos-blockchain/pull/3123); transaction traits refactored [#3168](https://github.com/logos-blockchain/logos-blockchain/pull/3168) and the tx module decomposed [#3169](https://github.com/logos-blockchain/logos-blockchain/pull/3169); stateless/stateful op verification split (in-review) [#3185](https://github.com/logos-blockchain/logos-blockchain/pull/3185)
+  - SDP `provider_id` and `zk_id` uniqueness enforced within a service [#3102](https://github.com/logos-blockchain/logos-blockchain/pull/3102), implementing the Per-Service Uniqueness RFC
+  - Wallet updated for channel participation in Proof of Stake: deposited notes kept with `ChannelTransfer`/`ChannelWithdraw` tracking [#3149](https://github.com/logos-blockchain/logos-blockchain/pull/3149), leadership participation with output notes [#3151](https://github.com/logos-blockchain/logos-blockchain/pull/3151), ownership of withdrawn notes [#3152](https://github.com/logos-blockchain/logos-blockchain/pull/3152)
+  - Chain-service main event loop reorganized into phases [#3162](https://github.com/logos-blockchain/logos-blockchain/pull/3162); blend readiness no longer awaited via timeout [#3158](https://github.com/logos-blockchain/logos-blockchain/pull/3158)
+  - Recovery state migrated to RocksDB: node state [#3134](https://github.com/logos-blockchain/logos-blockchain/pull/3134) and remaining services [#3159](https://github.com/logos-blockchain/logos-blockchain/pull/3159) merged, on top of the Overwatch runtime-handle support [Overwatch#142](https://github.com/logos-co/Overwatch/pull/142)
+  - Execution market: storage gas consumption now accumulated [#3181](https://github.com/logos-blockchain/logos-blockchain/pull/3181); spec base-fee fix based on `G_target` (in-review) [logos-lips#380](https://github.com/logos-co/logos-lips/pull/380)
+  - Dynamic merkle tree extracted and generalized [#3164](https://github.com/logos-blockchain/logos-blockchain/pull/3164); UTXOs exposed on transfer operations [#3163](https://github.com/logos-blockchain/logos-blockchain/pull/3163); genesis block root validated on deserialize (in-review) [#3161](https://github.com/logos-blockchain/logos-blockchain/pull/3161)
+  - API consistency: structured JSON error bodies merged [#3182](https://github.com/logos-blockchain/logos-blockchain/pull/3182); centralized typed HTTP errors (in-review) [#3172](https://github.com/logos-blockchain/logos-blockchain/pull/3172)
+
+- `blockchain:bedrock:eng:testing`
+  - Tokio-console profiling: Overwatch bump merged [#3148](https://github.com/logos-blockchain/logos-blockchain/pull/3148), task names and raw recording added [#3165](https://github.com/logos-blockchain/logos-blockchain/pull/3165)
+  - Heavy CI moved to a merge queue [#3176](https://github.com/logos-blockchain/logos-blockchain/pull/3176), [#3184](https://github.com/logos-blockchain/logos-blockchain/pull/3184)
+  - Flaky block-streaming test fixed: genesis time was computed too early [#3178](https://github.com/logos-blockchain/logos-blockchain/pull/3178)
+  - Wallet-scanner recovery from reorged snapshot seed tips (in-review) [#3180](https://github.com/logos-blockchain/logos-blockchain/pull/3180)
+
+- `blockchain:bedrock:eng:zone-sdk`
+  - L1 op identity and finalized slot surfaced on channel messages merged [#3147](https://github.com/logos-blockchain/logos-blockchain/pull/3147)
+  - Backfilling fixed: gap-backfilled inscriptions now surface as adopted, with an additional fix for orphaned finalized transactions (in-review) [#3079](https://github.com/logos-blockchain/logos-blockchain/pull/3079)
+  - C bindings implement the full `Node` interface, a prerequisite for a switchable API backend for the zone SDK (in-review) [#3173](https://github.com/logos-blockchain/logos-blockchain/pull/3173)
+
+- `blockchain:bedrock:eng:logos-core`
+  - Dashboard UI fixes merged: resume on the node view when a config exists [logos-blockchain-ui#40](https://github.com/logos-blockchain/logos-blockchain-ui/pull/40), long config paths elided [logos-blockchain-ui#43](https://github.com/logos-blockchain/logos-blockchain-ui/pull/43); backoff strategy for status polling (in-review) [logos-blockchain-ui#45](https://github.com/logos-blockchain/logos-blockchain-ui/pull/45)
+
+## `blockchain:logos-execution-zone`
+
+- `blockchain:logos-execution-zone:sequencer`
+  - Multi-sequencer wallet client merged [#600](https://github.com/logos-blockchain/logos-execution-zone/pull/600), with request distribution across multiple sequencers [#623](https://github.com/logos-blockchain/logos-execution-zone/pull/623); client parallelism (in-review) [#638](https://github.com/logos-blockchain/logos-execution-zone/pull/638)
+  - Common two-tip chain state for decentralized sequencing merged across indexer and sequencer [#603](https://github.com/logos-blockchain/logos-execution-zone/pull/603)
+  - Sequencer state bootstraps from Bedrock [#606](https://github.com/logos-blockchain/logos-execution-zone/pull/606)
+  - Decentralized-sequencing Sprint 2 scoped and planned [doc](https://app.notion.com/p/Sprint-2-3988f96fb65c805687b6dcec7b0f91ea); follow-up fixes opened (in-review) [#642](https://github.com/logos-blockchain/logos-execution-zone/pull/642)
+  - Multi-sequencer support for integration tests (WIP, draft) [#643](https://github.com/logos-blockchain/logos-execution-zone/pull/643)
+
+- `blockchain:logos-execution-zone:accounts`
+  - View-tag randomization for updated accounts merged [#591](https://github.com/logos-blockchain/logos-execution-zone/pull/591)
+  - Public transactions that silently drop a deposit are rejected [#625](https://github.com/logos-blockchain/logos-execution-zone/pull/625); `PrivateUnauthorized` authorization corrected [#621](https://github.com/logos-blockchain/logos-execution-zone/pull/621)
+  - Dummy-note padding via random seeding of nullifiers and commitments (in-review) [#592](https://github.com/logos-blockchain/logos-execution-zone/pull/592); ciphertext padding (in-review) [#630](https://github.com/logos-blockchain/logos-execution-zone/pull/630)
+  - Design of the authorization mechanism for private accounts written up [doc](https://hackmd.io/@tgReoUp4TR6_bM3e22EdBQ/SkVkPzNQzl)
+  - Private/public environment unification: aligning code and design decisions so semantics do not differ between private and public state (WIP) [branch](https://github.com/logos-blockchain/logos-execution-zone/compare/dev...artem/lee-environment-unification)
+
+- `blockchain:logos-execution-zone:wallet-ui`
+  - Signing with recipient keys dropped [#594](https://github.com/logos-blockchain/logos-execution-zone/pull/594); change-network command added [#596](https://github.com/logos-blockchain/logos-execution-zone/pull/596)
+  - Wallet UI: LEZ module renaming merged [logos-execution-zone-wallet-ui#27](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/27); public-account initialize button (in-review) [logos-execution-zone-wallet-ui#28](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/28); account labels [logos-execution-zone-wallet-ui#29](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/29) and improved private-account listing [logos-execution-zone-wallet-ui#30](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/30) opened (in-review); mnemonic recovery (WIP, draft) [logos-execution-zone-wallet-ui#31](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/31)
+
+- `blockchain:logos-execution-zone:cross-zone`
+  - Programs deployed at genesis instead of builtins merged [#615](https://github.com/logos-blockchain/logos-execution-zone/pull/615)
+  - Cross-zone generalization Phase 0 planned, with 2-3 PRs scoped [doc](https://app.notion.com/p/General-plan-3a68f96fb65c804eae7ace34befcecc3)
+
+- `blockchain:logos-execution-zone:keycard`
+  - Migration from keycard-py to keycard-rs merged in the keycard wallet [#595](https://github.com/logos-blockchain/logos-execution-zone/pull/595)
+
+## `nimbos`
+
+- Epoch state management merged [nimbos#126](https://github.com/logos-co/nimbos/pull/126)
+- SDP epoch snapshot mapping fixed to n+2 [nimbos#136](https://github.com/logos-co/nimbos/pull/136); non-mutating SDP/channel state transitions via sink parameters [nimbos#137](https://github.com/logos-co/nimbos/pull/137)
+- Gas metering opened (in-review) [nimbos#149](https://github.com/logos-co/nimbos/pull/149)
+- Block body validation [nimbos#142](https://github.com/logos-co/nimbos/pull/142) and block proposal spec [nimbos#143](https://github.com/logos-co/nimbos/pull/143) opened (WIP)

--- a/content/blockchain/updates/2026-08-03.md
+++ b/content/blockchain/updates/2026-08-03.md
@@ -1,0 +1,120 @@
+---
+title: 2026-08-03 Logos Blockchain weekly
+tags:
+  - nomos-updates
+date: 2026-08-03
+lastmod: 2026-08-03
+draft: false
+description: Weekly update of Logos Blockchain
+---
+
+# Logos Blockchain Weekly Update - 2026-08-03
+
+## `blockchain:highlights`
+
+- **Logos Execution Zone v0.2.1 released** [release](https://github.com/logos-blockchain/logos-execution-zone/releases/tag/v0.2.1)
+- **Blockchain Node 0.2.1-rc.3 pre-release published** [#3212](https://github.com/logos-blockchain/logos-blockchain/issues/3212)
+- **Cryptarchia with uncle references RFC opened** [logos-lips#385](https://github.com/logos-co/logos-lips/pull/385)
+- **Anonymous Leaders Reward Protocol merged in Nimbos** [nimbos#134](https://github.com/logos-co/nimbos/pull/134); **gas metering merged** [nimbos#149](https://github.com/logos-co/nimbos/pull/149)
+- **Total Stake Inference network-delay analysis finalized** [doc](https://app.notion.com/p/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0), [doc](https://app.notion.com/p/nomos-tech/Total-Stake-Inference-with-Network-Delays-372261aa09df82188afd01720e33a79c)
+- **Sequencer self-join mechanism designed** [doc](https://app.notion.com/p/Sequencer-self-join-specs-3ab8f96fb65c80a4b642d415b4a8f26b); **libp2p chosen for sequencer communication** [doc](https://app.notion.com/p/Analyze-and-decide-the-sequencer-communication-mechanism-3aa8f96fb65c80258b92c331bb579d55)
+
+## `blockchain:bedrock:research`
+
+- `blockchain:bedrock:research:cryptarchia`
+  - Fast Bootstrapping implementation prep: channel state [#3194](https://github.com/logos-blockchain/logos-blockchain/pull/3194), SDP declarations [#3208](https://github.com/logos-blockchain/logos-blockchain/pull/3208), locked notes [#3214](https://github.com/logos-blockchain/logos-blockchain/pull/3214), and voucher nullifiers [#3215](https://github.com/logos-blockchain/logos-blockchain/pull/3215) migrated to fixed blake2b merkle-tree structures
+  - Compressed Block Proposal RFC approved [doc](https://app.notion.com/p/nomos-tech/RFC-Compressed-Block-Proposal-2e3261aa09df80a38df7eb9f14ddeb5e); LIP opened (in-review) [logos-lips#389](https://github.com/logos-co/logos-lips/pull/389)
+  - Spec emergency fixes merged: `CHANNEL_DEPOSIT` execution and block limit [logos-lips#381](https://github.com/logos-co/logos-lips/pull/381), with implementation [#3189](https://github.com/logos-blockchain/logos-blockchain/pull/3189)
+
+- `blockchain:bedrock:research:post-quantum`
+  - Post-Quantum primitive benchmark document restructured with Rust results and cross-platform graphs [doc](https://app.notion.com/p/nomos-tech/Post-Quantum-Primitive-Benchmarks-390261aa09df80ad826ed884620222ce); dashboard extended to 4 platforms [dashboard](https://megonen.github.io/pqc-bench/)
+  - Post-Quantum Primitive Candidates for the Bedrock layer updated for consistency with the Blend and Bedrock safety analyses [doc](https://app.notion.com/p/nomos-tech/Post-Quantum-Primitive-Candidates-for-the-Logos-Bedrock-Layer-376261aa09df80348969f89b1f3ed8e9)
+
+- `blockchain:bedrock:research:total-stake-inference`
+  - "Modelling of Network Delays" [doc](https://app.notion.com/p/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0) and "Total Stake Inference with Network Delays" [doc](https://app.notion.com/p/nomos-tech/Total-Stake-Inference-with-Network-Delays-372261aa09df82188afd01720e33a79c) finalized and approved
+  - Cryptarchia with uncle references RFC opened (in-review) [logos-lips#385](https://github.com/logos-co/logos-lips/pull/385), backed by per-node Total Stake Inference simulations [code](https://github.com/logos-blockchain/research/tree/master/tools/simulators/tsi/tsi-sim-pernode) and gathered results [report](https://github.com/logos-blockchain/research/tree/master/reports/tsi)
+
+- `blockchain:bedrock:research:empowering`
+  - Acceleration-resistant Proof of Work survey completed [report](https://github.com/logos-blockchain/research/blob/master/reports/EmPoWering/Acceleration-Resistant-PoW-Survey.md); Equi-X benchmarking tool built [code](https://github.com/logos-blockchain/research/tree/master/tools/benchmarks/Equi-X) with analysis [report](https://github.com/logos-blockchain/research/tree/master/reports/EmPoWering/Equi-X)
+
+- `blockchain:bedrock:research:cross-zone-sequencing`
+  - Costly Abort Mechanism Direction 1 completed: `proposal_id` commitments provably tied to valid intents via a two-layer construction, audited end to end for self-consistency and optimism [doc](https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-396261aa09df80f99b7ffcd6ed76e0aa)
+  - Costly Abort Mechanism formal specification written [doc](https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-Specification-3ab261aa09df80c88844f4edd21e19de)
+
+- `blockchain:bedrock:research:anonymous-communications`
+  - Single-path mix latency law replaced with a shifted log-normal moment-matched to real inter-city pings, and a first mix-net grid layer built with a route-marginalising Bayesian attack [doc](https://app.notion.com/p/nomos-tech/Lognormal-single-path-mix-model-and-mixnet-c7c261aa09df82ada05681411003be88)
+  - Log-normal single-path mix model and Dandelion++ comparison write-up (WIP) [doc](https://nomos-tech.notion.site/Log-normal-Single-Path-Mix-Model-and-Dandelion-3b0261aa09df80678d59d03af2dd27b7)
+
+## `blockchain:bedrock:eng`
+
+- `blockchain:bedrock:eng:security-audit`
+  - Unified `BinaryEncode`/`BinaryDecode` trait system with fixture testing merged, replacing the legacy wire encoding [#3198](https://github.com/logos-blockchain/logos-blockchain/pull/3198), [#3201](https://github.com/logos-blockchain/logos-blockchain/pull/3201)
+  - Bounded-input hardening merged: bounded and validated merkle paths [#3183](https://github.com/logos-blockchain/logos-blockchain/pull/3183), bounded vecs replaced with fixed-size arrays [#3191](https://github.com/logos-blockchain/logos-blockchain/pull/3191), deposit inputs bounded [#3199](https://github.com/logos-blockchain/logos-blockchain/pull/3199), decode mitigations for bounded vectors [#3224](https://github.com/logos-blockchain/logos-blockchain/pull/3224)
+  - Remaining boundedness hardening (in-review): high-value candidates [#3225](https://github.com/logos-blockchain/logos-blockchain/pull/3225), serde JSON [#3228](https://github.com/logos-blockchain/logos-blockchain/pull/3228), alternate wire deserialisation paths [#3230](https://github.com/logos-blockchain/logos-blockchain/pull/3230)
+  - Dead/unused code cleanup (in-review) [#3227](https://github.com/logos-blockchain/logos-blockchain/pull/3227)
+
+- `blockchain:bedrock:eng:blend`
+  - Message encapsulation aligned with the spec: missing headers padded and payload padding randomised [#3217](https://github.com/logos-blockchain/logos-blockchain/pull/3217)
+  - Proof of Quota verification benchmarks added [#3197](https://github.com/logos-blockchain/logos-blockchain/pull/3197)
+
+- `blockchain:bedrock:eng:node`
+  - Operation typestate groundwork toward `SignedOp`: Op preverification unified [#3200](https://github.com/logos-blockchain/logos-blockchain/pull/3200); `VerificationMode` marker and Operation trait split (in-review) [#3234](https://github.com/logos-blockchain/logos-blockchain/pull/3234); `ProvableOperation` trait (in-review) [#3235](https://github.com/logos-blockchain/logos-blockchain/pull/3235)
+  - Execution market: fee prices rounded up so they can rise from low values [#3190](https://github.com/logos-blockchain/logos-blockchain/pull/3190) with the spec ceiling-formula fix [logos-lips#384](https://github.com/logos-co/logos-lips/pull/384); constants aligned with spec `G_max`/`G_target` [#3187](https://github.com/logos-blockchain/logos-blockchain/pull/3187)
+  - SDP declaration ID computation fixed with length-prefixed locators [logos-lips#386](https://github.com/logos-co/logos-lips/pull/386), [#3218](https://github.com/logos-blockchain/logos-blockchain/pull/3218)
+  - Pending mempool transactions evicted after a configurable TTL (in-review) [#3210](https://github.com/logos-blockchain/logos-blockchain/pull/3210); typed 404 responses for missing channels (in-review) [#3229](https://github.com/logos-blockchain/logos-blockchain/pull/3229)
+  - Mantle gas-cost APIs clarified as predictions, with per-operation minimum proof counts to avoid `InsufficientGas` errors [#3186](https://github.com/logos-blockchain/logos-blockchain/pull/3186)
+  - Cryptarchia walk-back functions hardened against potential infinite loops and panics (in-review) [#3209](https://github.com/logos-blockchain/logos-blockchain/pull/3209)
+  - Overwatch returns errors instead of panicking after shutdown [Overwatch#146](https://github.com/logos-co/Overwatch/pull/146); Rust toolchain updated to 1.97.1 [#3207](https://github.com/logos-blockchain/logos-blockchain/pull/3207), [Overwatch#147](https://github.com/logos-co/Overwatch/pull/147)
+
+- `blockchain:bedrock:eng:testing`
+  - Fee-market end-to-end tests merged: price rise/recovery scenarios [#3111](https://github.com/logos-blockchain/logos-blockchain/pull/3111) and tip-headroom coverage for gas price updates [#3223](https://github.com/logos-blockchain/logos-blockchain/pull/3223)
+  - Wallet-drain ability added to the cucumber suite [#3188](https://github.com/logos-blockchain/logos-blockchain/pull/3188); dead test code removed [#3205](https://github.com/logos-blockchain/logos-blockchain/pull/3205)
+  - Merge-queue CI hardened: workflow final steps fixed [#3193](https://github.com/logos-blockchain/logos-blockchain/pull/3193), fail-fast integration tests [#3203](https://github.com/logos-blockchain/logos-blockchain/pull/3203), merge-queue integration-test improvements [#3206](https://github.com/logos-blockchain/logos-blockchain/pull/3206)
+
+- `blockchain:bedrock:eng:zone-sdk`
+  - Funding priority fee made configurable [#3195](https://github.com/logos-blockchain/logos-blockchain/pull/3195)
+  - C bindings implement the full `Node` interface merged [#3173](https://github.com/logos-blockchain/logos-blockchain/pull/3173), with a default `Node` trait adapter [#3213](https://github.com/logos-blockchain/logos-blockchain/pull/3213), groundwork for a switchable API backend
+  - Backfilling fixes merged: gap-backfilled inscriptions surface as adopted, orphaned finalized transactions handled [#3079](https://github.com/logos-blockchain/logos-blockchain/pull/3079)
+  - Indexer removal in favor of the sequencer for reads and writes (in-review) [#3220](https://github.com/logos-blockchain/logos-blockchain/pull/3220); pending inscriptions invalidated on config update (in-review) [#3237](https://github.com/logos-blockchain/logos-blockchain/pull/3237)
+  - Zone SDK client packaging decided: `blockchain-module` becomes a mono-repo vendoring generated `logos-rust-sdk` code, so cargo builds no longer require nix
+
+- `blockchain:bedrock:eng:logos-core`
+  - Node 0.2.1-rc.3 pre-release published [#3212](https://github.com/logos-blockchain/logos-blockchain/issues/3212), with the blockchain module updated to match
+  - Backoff strategy for dashboard status polling merged [logos-blockchain-ui#45](https://github.com/logos-blockchain/logos-blockchain-ui/pull/45)
+  - FFI config environment-variable overrides fixed (in-review) [#3219](https://github.com/logos-blockchain/logos-blockchain/pull/3219); versioned Tools image built during releases (in-review) [#3221](https://github.com/logos-blockchain/logos-blockchain/pull/3221)
+
+## `blockchain:logos-execution-zone`
+
+- `blockchain:logos-execution-zone:release`
+  - Logos Execution Zone v0.2.1 released [release](https://github.com/logos-blockchain/logos-execution-zone/releases/tag/v0.2.1): Bedrock node and Zone SDK bumped [#654](https://github.com/logos-blockchain/logos-execution-zone/pull/654), dev merged to main [#661](https://github.com/logos-blockchain/logos-execution-zone/pull/661), [#663](https://github.com/logos-blockchain/logos-execution-zone/pull/663), nix packaging and artifacts-builder fixes [#658](https://github.com/logos-blockchain/logos-execution-zone/pull/658)
+
+- `blockchain:logos-execution-zone:sequencer`
+  - Multi-sequencer client parallelism merged [#638](https://github.com/logos-blockchain/logos-execution-zone/pull/638)
+  - Sequencer self-join/leave mechanism design finished [doc](https://app.notion.com/p/Sequencer-self-join-specs-3ab8f96fb65c80a4b642d415b4a8f26b); implementation opened (WIP, draft) [#653](https://github.com/logos-blockchain/logos-execution-zone/pull/653)
+  - Sequencer communication mechanism research concluded: libp2p chosen [doc](https://app.notion.com/p/Analyze-and-decide-the-sequencer-communication-mechanism-3aa8f96fb65c80258b92c331bb579d55); gossip module opened (WIP, draft) [#662](https://github.com/logos-blockchain/logos-execution-zone/pull/662)
+  - Channel config transactions funded via the node wallet [#659](https://github.com/logos-blockchain/logos-execution-zone/pull/659)
+  - Sequencer metrics and a Grafana dashboard generation tool (in-review) [#651](https://github.com/logos-blockchain/logos-execution-zone/pull/651)
+
+- `blockchain:logos-execution-zone:cross-zone`
+  - Generalization Phase 0 landed: forgery test gated on a verified peer-chain prefix [#649](https://github.com/logos-blockchain/logos-execution-zone/pull/649), watcher peer read cursors persisted [#652](https://github.com/logos-blockchain/logos-execution-zone/pull/652)
+
+- `blockchain:logos-execution-zone:accounts`
+  - Dummy-note padding merged [#592](https://github.com/logos-blockchain/logos-execution-zone/pull/592); note and cipher order obfuscation merged [#564](https://github.com/logos-blockchain/logos-execution-zone/pull/564)
+  - Private/public i/o bundled into action structs (in-review) [#604](https://github.com/logos-blockchain/logos-execution-zone/pull/604)
+  - Environment unification: public-private semantic discrepancies documented [doc](https://hackmd.io/@tgReoUp4TR6_bM3e22EdBQ/B1791IIBMl), proof-of-concept opened (WIP, draft) [#650](https://github.com/logos-blockchain/logos-execution-zone/pull/650), private-kinds refactor opened as part 1 of the unification PR stack (in-review) [#660](https://github.com/logos-blockchain/logos-execution-zone/pull/660)
+  - Incremental account updates explored (WIP, draft) [#656](https://github.com/logos-blockchain/logos-execution-zone/pull/656)
+
+- `blockchain:logos-execution-zone:proofs`
+  - Groth16 proving evaluated in the Logos Execution Zone: memory requirement identified as the limiting factor (draft) [#645](https://github.com/logos-blockchain/logos-execution-zone/pull/645)
+
+- `blockchain:logos-execution-zone:wallet-ui`
+  - Public-account initialize button merged [logos-execution-zone-wallet-ui#28](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/28); account labels merged [logos-execution-zone-wallet-ui#29](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/29)
+  - `lez_core` module updated to latest dev with new statistics FFI arguments (in-review) [logos-execution-zone-module#43](https://github.com/logos-blockchain/logos-execution-zone-module/pull/43)
+
+- `blockchain:logos-execution-zone:refactor`
+  - Valid-proof test removed from per-PR CI runs [#646](https://github.com/logos-blockchain/logos-execution-zone/pull/646)
+
+## `nimbos`
+
+- Anonymous Leaders Reward Protocol ledger state and claim path merged [nimbos#134](https://github.com/logos-co/nimbos/pull/134)
+- Gas metering merged [nimbos#149](https://github.com/logos-co/nimbos/pull/149)


### PR DESCRIPTION
Re-lands #514 against the new v5 base (v5 branched off before #514 merged, so these files were missing from it).

Adds the blockchain weekly updates for the reports dated 2026-07-13, 2026-07-20, 2026-07-27, and 2026-08-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)