### PR TITLE
Weekly rollups: 2026-07-27, 08-03, 08-10; backfill Blockchain into 07-20

### DIFF
--- a/content/reports/weekly/2026-07-06.html
+++ b/content/reports/weekly/2026-07-06.html
@@ -532,16 +532,16 @@
 
       <div class="stats-bar">
         <div class="stat">
-          <div class="stat-value">3</div>
+          <div class="stat-value">4</div>
           <div class="stat-label">Teams Reporting</div>
         </div>
         <div class="stat">
-          <div class="stat-value">80+</div>
+          <div class="stat-value">85+</div>
           <div class="stat-label">PRs &amp; Updates</div>
         </div>
       </div>
 
-      <p style="text-align:center; color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 1.5rem;">Note: AnonComms, Messaging, and Blockchain have reported. Storage and Logos Core sections will be added as their updates land.</p>
+      <p style="text-align:center; color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 1.5rem;">Note: AnonComms, Messaging, Blockchain, and Storage have reported. Logos Core section will be added as its update lands.</p>
 
       <section class="highlights-section">
         <h2>Key Highlights</h2>
@@ -578,6 +578,14 @@
             <div class="team">Blockchain</div>
             <p>Post-quantum Blend candidates document finalized with Raspberry Pi 5 and Apple M3 benchmarks published; cross-zone messaging browser demo opened for review.</p>
           </div>
+          <div class="highlight-card storage">
+            <div class="team">Storage</div>
+            <p><strong>Maintenance releases for Logos Storage Module and UI v2.0.1</strong>, shipping support for DHT queries over mix &mdash; completing the round of deliverables for the Logos v0.2 testnet.</p>
+          </div>
+          <div class="highlight-card storage">
+            <div class="team">Storage</div>
+            <p>Studied Tor's <code>guard</code> and <code>vanguard</code> specs and experimented with the guard approach over mix, building understanding of the malicious-path problem for hidden services.</p>
+          </div>
         </div>
       </section>
 
@@ -593,6 +601,7 @@
         <button class="tab messaging active" data-team="messaging">Messaging</button>
         <button class="tab blockchain" data-team="blockchain">Blockchain</button>
         <button class="tab anoncomms" data-team="anoncomms">AnonComms</button>
+        <button class="tab storage" data-team="storage">Storage</button>
       </div>
 
       <!-- ================================================================
@@ -1223,6 +1232,54 @@
                   <li>Address PR12 review comments and continue on PR13</li>
                   <li>Keep reviewing PRs</li>
                   <li>Continue POC upgrade and testing</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ================================================================
+             STORAGE
+             ================================================================ -->
+      <div class="team-content" id="storage">
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-nim/milestone/10">Integration with Logos Core</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Testnet maintenance release</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>New testnet release (Storage/UI v2.0.1)</strong>:
+                    <ul>
+                      <li><a href="https://github.com/logos-co/logos-storage-module/releases/tag/v2.0.1">logos-storage-module@2.0.1</a></li>
+                      <li><a href="https://github.com/logos-co/logos-storage-ui/releases/tag/v2.0.1">logos-storage-ui@2.0.1</a> &mdash; ships support for DHT queries over mix</li>
+                    </ul>
+                  </li>
+                  <li>Together with what was released <a href="./2026-06-29.html">last week</a>, this completes the round of deliverables for the Logos v0.2 testnet</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/20">Hidden Services Over Mix</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Malicious-path research</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Studied the <a href="https://spec.torproject.org/guard-spec/index.html">guard</a> and <a href="https://spec.torproject.org/vanguards-spec/">vanguard</a> specs that Tor uses to get a better understanding of the malicious-path problem</li>
+                  <li>Experimented with the guard approach over mix as described in the <a href="https://dl.acm.org/doi/pdf/10.1145/3564625.3567996">paper</a></li>
                 </ul>
               </div>
             </div>

--- a/content/reports/weekly/2026-07-13.html
+++ b/content/reports/weekly/2026-07-13.html
@@ -521,21 +521,21 @@
 
       <nav class="week-nav">
         <a class="prev" data-router-ignore href="/reports/weekly/2026-07-06.html">&larr; 2026-07-06</a>
-        <span class="spacer"></span>
+        <a class="next" data-router-ignore href="/reports/weekly/2026-07-20.html">2026-07-20 &rarr;</a>
       </nav>
 
       <div class="stats-bar">
         <div class="stat">
-          <div class="stat-value">1</div>
+          <div class="stat-value">2</div>
           <div class="stat-label">Teams Reporting</div>
         </div>
         <div class="stat">
-          <div class="stat-value">10+</div>
+          <div class="stat-value">20+</div>
           <div class="stat-label">PRs &amp; Updates</div>
         </div>
       </div>
 
-      <p style="text-align:center; color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 1.5rem;">Note: Only AnonComms has reported so far this week. Other team sections will be added as updates land.</p>
+      <p style="text-align:center; color: var(--text-secondary); font-size: 0.9rem; margin-bottom: 1.5rem;">Note: AnonComms and Storage have reported. Messaging, Blockchain, and Logos Core sections will be added as their updates land.</p>
 
       <section class="highlights-section">
         <h2>Key Highlights</h2>
@@ -560,6 +560,14 @@
             <div class="team">AnonComms</div>
             <p>RLN module ported to the Logos Core Rust SDK; Keycard device key explored as an authentication method for acquiring RLN membership.</p>
           </div>
+          <div class="highlight-card storage">
+            <div class="team">Storage</div>
+            <p><strong>Hidden-service-over-Mix simulator built</strong> &mdash; extended the mix simulator from the <a href="https://dl.acm.org/doi/pdf/10.1145/3564625.3567996">ACM paper</a> with a hidden-service model using guards and vanguards (<a href="https://github.com/logos-storage/hs-mix-sim">hs-mix-sim</a>).</p>
+          </div>
+          <div class="highlight-card storage">
+            <div class="team">Storage</div>
+            <p>Kicked off an effort to centralise all Logos Storage <a href="https://hackmd.io/@codex-storage/rJNzTdOQzl">documentation into a Docusaurus site</a> with C/C++/OpenAPI reference generation; <a href="https://emizzle.github.io/logos-storage-docs/node">prototype live</a>.</p>
+          </div>
         </div>
       </section>
 
@@ -573,6 +581,7 @@
 
       <div class="tabs">
         <button class="tab anoncomms active" data-team="anoncomms">AnonComms</button>
+        <button class="tab storage" data-team="storage">Storage</button>
       </div>
 
       <!-- ================================================================
@@ -763,6 +772,116 @@
                 <span class="section-label next">Next</span>
                 <ul class="item-list">
                   <li>Consolidate on the appropriate approach and move forward</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             STORAGE
+             ================================================================ -->
+      <div class="team-content" id="storage">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/20">Hidden Services Over Mix</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Hidden service simulator over Mix</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Improved the mix simulator</strong> from the <a href="https://dl.acm.org/doi/pdf/10.1145/3564625.3567996">reference paper</a> and implemented a hidden-service model to simulate a hidden service over mix with guards and vanguards</li>
+                  <li>Simulator repository: <a href="https://github.com/logos-storage/hs-mix-sim">hs-mix-sim</a> (NEW)</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Summarize the simulation results and add the figures in a document</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-nim/milestone/10">Integration with Logos Core</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>UI/UX &amp; documentation improvements</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Meeting with Aqeel to discuss UI / UX improvements</li>
+                  <li>Improved <a href="https://github.com/logos-co/logos-docs/pull/392">documentation</a></li>
+                  <li>Added <a href="https://github.com/logos-co/logos-storage-ui/pull/68">configuration versioning</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/5">NAT Traversal</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>libplum protocol filtering API</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Provided an API to <a href="https://github.com/logos-storage/nim-libplum/pull/15">filter the protocol</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Switch back to <code>paullouisageneau/libplum</code> head after <a href="https://github.com/paullouisageneau/libplum/pull/56">upstream PR 56</a> is merged</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>General improvements</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Releases, fixes &amp; bindings</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Added <a href="https://github.com/logos-storage/logos-storage-nim/pull/1488">libstorage static artefacts</a> to release</li>
+                  <li>Fixed a <a href="https://github.com/logos-storage/logos-storage-nim/pull/1486">crash with UPnP</a></li>
+                  <li>Provided a better <a href="https://github.com/logos-storage/logos-storage-nim/pull/1487">shutdown process</a></li>
+                  <li>Updated <a href="https://github.com/logos-storage/logos-storage-go-bindings/pull/27">Go bindings</a></li>
+                  <li>Rust bindings update on hold (waiting for repo access)</li>
+                </ul>
+                <span class="section-label blockers">Blockers</span>
+                <ul class="item-list">
+                  <li>Repo access needed to update Rust bindings</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Documentation consolidation into Docusaurus</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Kicked off an effort to centralise all Logos Storage documentation</strong> into a Docusaurus site with C/C++/OpenAPI API reference generation &mdash; <a href="https://hackmd.io/@codex-storage/rJNzTdOQzl">planning note</a></li>
+                  <li>Prototype live: <a href="https://emizzle.github.io/logos-storage-docs/node">logos-storage-docs</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Meeting with EcoDev to discuss moving all documentation into <code>docs.logos.co</code> instead of maintaining a separate repo and mirroring</li>
                 </ul>
               </div>
             </div>

--- a/content/reports/weekly/2026-07-20.html
+++ b/content/reports/weekly/2026-07-20.html
@@ -1,0 +1,1369 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logos Collective Weekly Summary - Week 29, 2026</title>
+    <style>
+      :root {
+        --bg-primary: #0d1117;
+        --bg-secondary: #161b22;
+        --bg-tertiary: #21262d;
+        --text-primary: #f0f6fc;
+        --text-secondary: #8b949e;
+        --border-color: #30363d;
+        --accent-storage: #3fb950;
+        --accent-messaging: #58a6ff;
+        --accent-logoscore: #a371f7;
+        --accent-blockchain: #f78166;
+        --accent-anoncomms: #d2a8ff;
+        --highlight-bg: rgba(56, 139, 253, 0.15);
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial,
+          sans-serif;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        line-height: 1.6;
+        min-height: 100vh;
+      }
+
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem;
+      }
+
+      header {
+        text-align: center;
+        margin-bottom: 3rem;
+        padding-bottom: 2rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      header h1 {
+        font-size: 2.5rem;
+        margin-bottom: 0.5rem;
+        background: linear-gradient(135deg, #58a6ff, #a371f7);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+
+      header .date {
+        color: var(--text-secondary);
+        font-size: 1.1rem;
+      }
+
+      .highlights-section {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        padding: 2rem;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .highlights-section h2 {
+        margin-bottom: 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .highlights-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+      }
+
+      .highlight-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        border-left: 4px solid;
+        transition:
+          transform 0.2s,
+          box-shadow 0.2s;
+      }
+
+      .highlight-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      .highlight-card.storage {
+        border-left-color: var(--accent-storage);
+      }
+      .highlight-card.messaging {
+        border-left-color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore {
+        border-left-color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain {
+        border-left-color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms {
+        border-left-color: var(--accent-anoncomms);
+      }
+
+      .highlight-card .team {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.5rem;
+        opacity: 0.8;
+      }
+
+      .highlight-card.storage .team {
+        color: var(--accent-storage);
+      }
+      .highlight-card.messaging .team {
+        color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore .team {
+        color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain .team {
+        color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms .team {
+        color: var(--accent-anoncomms);
+      }
+
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+      }
+
+      .tab {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: all 0.2s;
+        border: 1px solid var(--border-color);
+      }
+
+      .tab:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+      }
+
+      .tab.active {
+        color: var(--text-primary);
+      }
+
+      .tab.active.storage {
+        background: var(--accent-storage);
+        color: #000;
+      }
+      .tab.active.messaging {
+        background: var(--accent-messaging);
+        color: #000;
+      }
+      .tab.active.logoscore {
+        background: var(--accent-logoscore);
+        color: #000;
+      }
+      .tab.active.blockchain {
+        background: var(--accent-blockchain);
+        color: #000;
+      }
+      .tab.active.anoncomms {
+        background: var(--accent-anoncomms);
+        color: #000;
+      }
+
+      .team-content {
+        display: none;
+        animation: fadeIn 0.3s ease;
+      }
+
+      .team-content.active {
+        display: block;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      .milestone {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 1.5rem;
+        border: 1px solid var(--border-color);
+        overflow: hidden;
+      }
+
+      .milestone-header {
+        padding: 1rem 1.5rem;
+        background: var(--bg-tertiary);
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        user-select: none;
+      }
+
+      .milestone-header:hover {
+        background: rgba(48, 54, 61, 0.8);
+      }
+
+      .milestone-header h3 {
+        font-size: 1.1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .milestone-header h3 a {
+        color: var(--text-primary);
+        text-decoration: none;
+      }
+
+      .milestone-header h3 a:hover {
+        text-decoration: underline;
+      }
+
+      .milestone-toggle {
+        font-size: 1.5rem;
+        color: var(--text-secondary);
+        transition: transform 0.3s;
+      }
+
+      .milestone.expanded .milestone-toggle {
+        transform: rotate(180deg);
+      }
+
+      .milestone-body {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease;
+      }
+
+      .milestone.expanded .milestone-body {
+        max-height: 5000px;
+      }
+
+      .milestone-content {
+        padding: 1.5rem;
+      }
+
+      .deliverable {
+        margin-bottom: 1.5rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .deliverable:last-child {
+        margin-bottom: 0;
+        padding-bottom: 0;
+        border-bottom: none;
+      }
+
+      .deliverable h4 {
+        font-size: 1rem;
+        margin-bottom: 1rem;
+        color: var(--text-primary);
+      }
+
+      .deliverable h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .deliverable h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .section-label {
+        display: inline-block;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        margin-bottom: 0.5rem;
+      }
+
+      .section-label.achieved {
+        background: rgba(63, 185, 80, 0.2);
+        color: var(--accent-storage);
+      }
+
+      .section-label.next {
+        background: rgba(88, 166, 255, 0.2);
+        color: var(--accent-messaging);
+      }
+
+      .section-label.blockers {
+        background: rgba(247, 129, 102, 0.2);
+        color: var(--accent-blockchain);
+      }
+
+      .item-list {
+        list-style: none;
+        margin-left: 0;
+      }
+
+      .item-list li {
+        padding: 0.5rem 0;
+        padding-left: 1.5rem;
+        position: relative;
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+      }
+
+      .item-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.85rem;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--text-secondary);
+      }
+
+      .item-list li a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .item-list li a:hover {
+        text-decoration: underline;
+      }
+
+      .stats-bar {
+        display: flex;
+        gap: 2rem;
+        padding: 1rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+      }
+
+      .stat {
+        text-align: center;
+      }
+
+      .stat-value {
+        font-size: 2rem;
+        font-weight: 700;
+      }
+
+      .stat-label {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .repo-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 1rem;
+      }
+
+      .repo-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .repo-card h4 {
+        font-size: 0.95rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .repo-card h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .repo-card h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .repo-card p {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .pr-list {
+        margin-top: 0.5rem;
+      }
+
+      .pr-list a {
+        display: inline-block;
+        font-size: 0.8rem;
+        color: #58a6ff;
+        margin-right: 0.5rem;
+        text-decoration: none;
+      }
+
+      .pr-list a:hover {
+        text-decoration: underline;
+      }
+
+      .search-box {
+        margin-bottom: 1.5rem;
+      }
+
+      .search-box input {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+
+      .search-box input::placeholder {
+        color: var(--text-secondary);
+      }
+
+      .search-box input:focus {
+        outline: none;
+        border-color: #58a6ff;
+        box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.2);
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      footer {
+        text-align: center;
+        padding: 2rem;
+        color: var(--text-secondary);
+        border-top: 1px solid var(--border-color);
+        margin-top: 3rem;
+      }
+
+      @media (max-width: 768px) {
+        .container {
+          padding: 1rem;
+        }
+
+        header h1 {
+          font-size: 1.75rem;
+        }
+
+        .stats-bar {
+          justify-content: space-around;
+        }
+
+        .stat-value {
+          font-size: 1.5rem;
+        }
+      }
+      /* week-nav-css */
+      .week-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+        padding: 0.75rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .week-nav a {
+        color: var(--text-primary);
+        text-decoration: none;
+        padding: 0.5rem 1rem;
+        border-radius: 8px;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: background 0.2s;
+      }
+      .week-nav a:hover {
+        background: var(--bg-tertiary);
+      }
+      .week-nav .prev { margin-right: auto; }
+      .week-nav .next { margin-left: auto; }
+      .week-nav .spacer { flex: 1; }
+      /* /week-nav-css */
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Logos Collective Weekly Summary</h1>
+        <p class="date">Week 29, 2026 (July 20, 2026)</p>
+      </header>
+
+      <nav class="week-nav">
+        <a class="prev" data-router-ignore href="/reports/weekly/2026-07-13.html">&larr; 2026-07-13</a>
+        <span class="spacer"></span>
+      </nav>
+
+      <div class="stats-bar">
+        <div class="stat">
+          <div class="stat-value">4</div>
+          <div class="stat-label">Teams Reporting</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">130+</div>
+          <div class="stat-label">PRs &amp; Updates</div>
+        </div>
+      </div>
+
+      <section class="highlights-section">
+        <h2>Key Highlights</h2>
+        <div class="highlights-grid">
+          <div class="highlight-card messaging">
+            <div class="team">Messaging</div>
+            <p><strong>GroupV2 client integration</strong> landed in <code>libchat</code> alongside membership-change surfacing and PrivateV1 conversation stack removal.</p>
+          </div>
+          <div class="highlight-card messaging">
+            <div class="team">Messaging</div>
+            <p>Structured API layers plus new <code>logos_delivery_node</code> app with REST API and event observability shipped in <code>logos-delivery</code>.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p><strong>LIONESS payload encryption for Sphinx merged</strong> into <code>nim-libp2p-mix</code>, confirmed integrating with Logos Delivery without issues.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p>First draft of the RLN membership management module API spec opened for review; anonymised-messaging docs published for testnet v0.2.</p>
+          </div>
+          <div class="highlight-card storage">
+            <div class="team">Storage</div>
+            <p>Free-route mix simulator (<code>freeroutesim</code>) completed for studying path selection and the malicious-path problem in hidden services over Mix.</p>
+          </div>
+          <div class="highlight-card logoscore">
+            <div class="team">Logos Core</div>
+            <p>Full-API doctest chain landed across <code>logos-basecamp</code>, <code>logos-cpp-sdk</code>, <code>logos-rust-sdk</code>, and <code>logos-logoscore-cli</code>; shared semver implementation unified across the packaging stack.</p>
+          </div>
+        </div>
+      </section>
+
+      <div class="search-box">
+        <input
+          type="text"
+          id="search"
+          placeholder="Search updates (e.g., 'RLN', 'LIONESS', 'LEZ', 'semver', 'GroupV2')..."
+        />
+      </div>
+
+      <div class="tabs">
+        <button class="tab messaging active" data-team="messaging">Messaging</button>
+        <button class="tab anoncomms" data-team="anoncomms">AnonComms</button>
+        <button class="tab storage" data-team="storage">Storage</button>
+        <button class="tab logoscore" data-team="logoscore">Logos Core</button>
+      </div>
+
+      <!-- ================================================================
+             MESSAGING
+             ================================================================ -->
+      <div class="team-content active" id="messaging">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Messaging API &mdash; Beta</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Test suite for Messaging API</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4020">Fix interop tests</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/414">Stabilize and improve Messaging API, fix bugs</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/3956">Structured API layers</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4014">feat: <code>logos_delivery_node</code> app + messaging REST API with event observability</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4015">feat: improve config</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4022">Move api config modules to <code>api/conf/</code></a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4024">chore: move conf types to <code>api/conf</code></a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4023">Fix FFI peerId pretty print</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Reliable Channel API &mdash; Developer Preview</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/412">Implement Reliable Channel API</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4045">feat(channels): add <code>channelExists</code> to reliable channels API</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4051">fix(channels): default channels to unencrypted so messages flow</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery-interop-tests/issues/191">E2E testing of LogosDelivery Reliable Channel API</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Reliable Channel API &mdash; Beta</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Add Rate Limit Manager to Reliable Channel API</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4054">RLN rate-limiting: epoch/nonce misalignment and budget gaps</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4021">Move rate-limit-manager to messaging client layer</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4042">feat: rate-limit enforcement and RLN proofing at the send service transmission stage</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4050">feat: enforce per-epoch budget in <code>RateLimitManager.admit</code></a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4031">Implement Rate limit manager</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Support QUIC Transport in Logos Delivery</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/324">Trial QUIC</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/3986">feat: DST scale validation of QUIC transport</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-messaging/pm/issues/411">RLN for Edge Nodes</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/344">Improve RLN UX by reducing contract interactions</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4013">Refresh merkle proof cache reactively on msg publish rejection</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Port RLN to Logos Blockchain</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/416">Implement pluggable RLN membership interface</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4016">Define RLN interface API</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4034">Implement proper api folder structure for RLN</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Fleet Stability</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/382">Fleet monitoring dashboards for Logos fleets</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4040">Group and simplify sonda metrics</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4053">fix: bound the error label of <code>failed_store_queries</code></a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/384">Resolve known fleet stability issues</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4029">fix: don't apply reconnect backoff to discovered relay peers</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4041">Bump nim-libp2p to v2.2.0 and replace <code>nat_traversal</code> with libp2p <code>NATConfig</code></a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Chat &mdash; Developer Preview</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/346">Add Group Chat</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>GroupV2 Client Integration</strong> &mdash; <a href="https://github.com/logos-messaging/libchat/pull/167">libchat #167</a>, <a href="https://github.com/logos-co/logos-chat-module/pull/43">logos-chat-module #43</a></li>
+                  <li>Remove PrivateV1 Conversation Stack &mdash; <a href="https://github.com/logos-messaging/libchat/pull/176">libchat #176</a></li>
+                  <li>Surface membership-changes &mdash; <a href="https://github.com/logos-messaging/libchat/pull/177">libchat #177</a>, <a href="https://github.com/logos-co/logos-chat-module/pull/47">logos-chat-module #47</a></li>
+                  <li>Isolate &amp; expose chat delivery library &mdash; <a href="https://github.com/logos-messaging/libchat/pull/178">libchat #178</a></li>
+                  <li>Expose Groupname in Client &mdash; <a href="https://github.com/logos-messaging/libchat/pull/183">libchat #183</a>, <a href="https://github.com/logos-co/logos-chat-module/pull/48">logos-chat-module #48</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Maintenance</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Fixes &amp; Improvements</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/3955">Refactor: replace all <code>Option</code> (std/options) with <code>Opt</code> (results)</a></li>
+                  <li>nim-ffi: <a href="https://github.com/logos-messaging/nim-ffi/pull/129">feat(ffi): <code>RET_STALE_WARN</code> progress callback replacing handler timeout</a></li>
+                  <li>nim-ffi: <a href="https://github.com/logos-messaging/nim-ffi/pull/128">fix(test): rebuild CBOR libecho in cpp e2e to avoid ABI mismatch</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4046">chore: replace <code>minprotobuf</code> with <code>nim-protobuf-serialization</code></a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4044">Standardize the use of Persistence</a></li>
+                  <li>nocopy message path PoC: <a href="https://github.com/logos-messaging/logos-delivery/pull/4036">1/3 perf harness</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4037">2/3 WakuMessage as ref object</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4038">3/3 WakuEnvelope decode once</a></li>
+                  <li><a href="https://github.com/logos-messaging/nim-ffi/issues/112">Lossless event delivery: unbounded intrusive SPSC queue + node freelist</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4033">chore: improve on RLN merkle proof and root refresh logic</a></li>
+                  <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4030">Reduce RLN tests duration</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             ANONCOMMS
+             ================================================================ -->
+      <div class="team-content" id="anoncomms">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Establish libp2p mixnet</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/50">Implement LIONESS payload encryption for Sphinx</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Merged LIONESS payload encryption</strong> &mdash; <a href="https://github.com/logos-co/nim-libp2p-mix/pull/30">nim-libp2p-mix #30</a></li>
+                  <li>Confirmed integration with <code>logos-delivery</code> works without any issues</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/52">Implement local reputation mechanism and research advanced DoS protection</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Explored Blend's PoQ + PoSel for Mix &mdash; precompute is PoQ's only real edge over RLN</li>
+                  <li>Researched a way to keep slashing with precomputed proofs</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Finalise the PoQ + PoSel for Mix analysis</li>
+                  <li>Draft the per-hop PoQ with slashing spec</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Implement RLN membership allocation service</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/78">Specify basic RLN membership management module API</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>First draft of spec opened for review</strong> &mdash; <a href="https://github.com/logos-co/logos-lips/pull/373">logos-lips #373</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/79">Implement basic RLN membership management module</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Working <code>logos-core</code> module and UI, tested against testnet with corresponding journey &mdash; <a href="https://github.com/logos-co/logos-docs/issues/403">logos-docs #403</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Create a basic service discovery module</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/36">Validate service discovery protocol correctness in large-scale simulations</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>IPv6 implementation <a href="https://github.com/vacp2p/nim-libp2p/pull/2805">PR</a> merged in <code>nim-libp2p</code></li>
+                  <li>Collaboration with DST on service discovery bug analysis</li>
+                  <li>PR reviews</li>
+                  <li><a href="https://github.com/logos-co/logos-lips/pull/374">PR to fix bucket distance formula in RFC</a></li>
+                  <li>Investigation, refactoring, and bug fixes</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Continue service discovery investigation and bug fixes</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Deliver de-MLS for p2p group messaging</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/62">Implementing recovery mode</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Fixed a race condition in proposal creation</li>
+                  <li>Started work on a manual commit/recover trigger</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Integrate the new architecture into <code>libchat</code></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/61">Implementing a WallClock service for de-MLS timing</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Adjust the WallClock service</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Decentralised Oracle Network</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/56">Specifying oracle mechanism</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Revised oracle spec &mdash; <a href="https://github.com/logos-co/logos-lips/pull/366">logos-lips #366</a> with a new approach</li>
+                  <li>Reviewed the oracle spec PR and cleaned up previous review comments</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Merge the spec, continue with future work and edge cases, and run more experiments to improve the spec</li>
+                  <li>Discuss missing points in the current PR version</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Implement an MVP payment protocol</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/73">Specify and implement client payment shielding via LEZ private execution mode</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Implementation plan for privacy mode in payment streams</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Implement the plan, fix possible issues</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Maintain and expand Zerokit</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/60">Release Zerokit (v3.0.0) with enum-based runtime configuration</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Addressed comments in <a href="https://github.com/vacp2p/zerokit/pull/425">PR14</a> and reviewed <a href="https://github.com/vacp2p/zerokit/pull/426">PR426</a></li>
+                  <li>Implemented a validation mechanism for all input paths</li>
+                  <li>Zerokit PR reviews and discussion</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Complete and merge PR14 to the develop v3 branch</li>
+                  <li>Continue Zerokit PR reviews</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             STORAGE
+             ================================================================ -->
+      <div class="team-content" id="storage">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/20">Hidden Services Over Mix</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Free-route mix simulator</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Completed the implementation</strong> of the free-route mix <a href="https://github.com/logos-storage/hs-mix-sim/tree/main/crates/freeroutesim"><code>freeroutesim</code></a> simulator for simulating the path selection and malicious-path problem &mdash; helps study the problem better in the mix protocol we are using.</li>
+                  <li>Improved documentation of the simulator and results.</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Continue research and study the problem in the context of anonymous download using the transport layer since the problem still exists there.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-nim/milestone/10">Integration with Logos Core</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Logos Storage UI &amp; Design System alignment</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Implemented the menu in the app</li>
+                  <li>Extended the <a href="https://github.com/logos-co/logos-design-system/pull/30">button</a> in Logos Design System to support icons</li>
+                  <li>Extended the <a href="https://github.com/logos-co/logos-design-system/pull/31">textfield</a> in Logos Design System to support validation</li>
+                  <li>Extended the <a href="https://github.com/logos-co/logos-design-system/pull/32">frame</a> in Logos Design System to support custom radius</li>
+                  <li>Extended the <a href="https://github.com/logos-co/logos-design-system/pull/35">button icon</a> in Logos Design System to support hover animation</li>
+                  <li>Extended the <a href="https://github.com/logos-co/logos-design-system/pull/33">textfield</a> in Logos Design System to support read-only attribute</li>
+                  <li><strong>Aligned the Logos Storage UI with the Logos Design System</strong></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Implement missing UI elements in Logos Storage UI from the Design</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Storage Documentation</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Migration to Docusaurus</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Meeting with EcoDev &mdash; they will migrate to Docusaurus, and a workflow for generic API generation is OK to implement.</li>
+                  <li>Created <code>logos-storage/logos-storage-docs</code> as a temp repo to centralise all Logos Storage documentation into while we wait for <code>docs.logos.co</code> to migrate to Docusaurus.</li>
+                  <li>Began setting up the repo as a Docusaurus site to make migration to <code>docs.logos.co</code> easier once it has been set up.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Misc</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Wire protocol serialization</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Migrated all wire protocols from <code>minprotobuf</code> to <a href="https://github.com/status-im/nim-protobuf-serialization"><code>nim-protobuf-serialization</code></a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             LOGOS CORE
+             ================================================================ -->
+      <div class="team-content" id="logoscore">
+        <div class="repo-list">
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-basecamp">logos-basecamp</a></h4>
+            <p>Doctest full sync+async UI runs with cross-version cases; QDockWidgets adoption; install/upgrade confirmation dialog with dep-change list; graceful SIGTERM handling for UI modules.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-basecamp/pull/272">#272</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/267">#267</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/266">#266</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/265">#265</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/264">#264</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/263">#263</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/262">#262</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/261">#261</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/260">#260</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/259">#259</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/258">#258</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/257">#257</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/256">#256</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/249">#249</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/244">#244</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-chat-module">logos-chat-module</a></h4>
+            <p>Message preview in conversation summaries, group name/description surfacing, and roster changes as <code>members_changed</code> events.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-chat-module/pull/49">#49</a>
+              <a href="https://github.com/logos-co/logos-chat-module/pull/48">#48</a>
+              <a href="https://github.com/logos-co/logos-chat-module/pull/47">#47</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-chat-ui">logos-chat-ui</a></h4>
+            <p>Chat UI UX polish, group creation with name/description, Logos Design System + ChatUi refactor, and pending indicators for member-add.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/40">#40</a>
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/36">#36</a>
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/35">#35</a>
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/34">#34</a>
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/33">#33</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-cpp-sdk">logos-cpp-sdk</a></h4>
+            <p>Codegen fixes for T-array arg packing, any-value return, bstr + composite-any type handling; binary payload encoding in cdylib events fixed.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/106">#106</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/105">#105</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/104">#104</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/103">#103</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/102">#102</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/100">#100</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-liblogos">logos-liblogos</a></h4>
+            <p>Re-pinned to <code>logos-protocol</code> master for <code>LogosAPIConsumer</code> handle cache and nested-bytes fix.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-liblogos/pull/163">#163</a>
+              <a href="https://github.com/logos-co/logos-liblogos/pull/162">#162</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-logoscore-cli">logos-logoscore-cli</a></h4>
+            <p>Doctest full_api chain (cross-language proxies, events, arrays); <code>call</code> passes lists/maps via <code>json:</code>/<code>str:</code> argument prefixes.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/70">#70</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/69">#69</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/68">#68</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/67">#67</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/65">#65</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-logoscore-py">logos-logoscore-py</a></h4>
+            <p>Bumped <code>flake.lock</code> and <code>logoscore-cli</code>.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/8">#8</a>
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/7">#7</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-module-builder">logos-module-builder</a></h4>
+            <p>Auto-generated <code>qmldir</code> at <code>ui_qml</code> entry dir with per-module URI; SDK re-pins for full_api and bstr event fixes.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-module-builder/pull/151">#151</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/150">#150</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/149">#149</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/148">#148</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-module-client">logos-module-client</a></h4>
+            <p>Bumped <code>logos-protocol</code> to master for nested-bytes <code>qvariantToNlohmann</code> fix.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-module-client/pull/11">#11</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package">logos-package</a></h4>
+            <p><strong>One semver implementation for the packaging stack.</strong></p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package/pull/30">#30</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-downloader">logos-package-downloader</a></h4>
+            <p>Top-level pinned dep no longer re-resolved to newest as transitive; catalog versions now ranked by semver precedence, not release date.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-downloader/pull/18">#18</a>
+              <a href="https://github.com/logos-co/logos-package-downloader/pull/17">#17</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-downloader-module">logos-package-downloader-module</a></h4>
+            <p><code>downloadResolvedDependencies</code> keeps already-installed satisfying deps; re-pinned to shared-semver master.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-downloader-module/pull/17">#17</a>
+              <a href="https://github.com/logos-co/logos-package-downloader-module/pull/16">#16</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-manager">logos-package-manager</a></h4>
+            <p>Use the shared semver implementation, and stop clobbering newer packages.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-manager/pull/25">#25</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-manager-module">logos-package-manager-module</a></h4>
+            <p>Fresh-install gate with dep changes threaded through the gated flow; re-pinned to shared-semver master.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-manager-module/pull/57">#57</a>
+              <a href="https://github.com/logos-co/logos-package-manager-module/pull/56">#56</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-manager-ui">logos-package-manager-ui</a></h4>
+            <p>Route install/upgrade confirmation through the host gate; always confirm installs and pass installed set to the download path; row Action uses shared semver.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-manager-ui/pull/53">#53</a>
+              <a href="https://github.com/logos-co/logos-package-manager-ui/pull/52">#52</a>
+              <a href="https://github.com/logos-co/logos-package-manager-ui/pull/51">#51</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-protocol">logos-protocol</a></h4>
+            <p>Cache remote-object handle per name in <code>LogosAPIConsumer</code>; keep nested bytes/ints tagged in <code>qvariantToNlohmann</code> containers; async call error channel fixes.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-protocol/pull/24">#24</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/23">#23</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/21">#21</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/19">#19</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-qt-sdk">logos-qt-sdk</a></h4>
+            <p>Handle <code>QVariantList</code>/<code>QVariantMap</code> args in reflection dispatch; protocol bump for nested-bytes fix.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/12">#12</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/10">#10</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-rust-sdk">logos-rust-sdk</a></h4>
+            <p><code>lidl-gen</code> clones <code>any</code> event params instead of <code>Value::from</code>; fix event emitter dropping <code>bstr</code> <code>payload</code> arg with binary event tests.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/26">#26</a>
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/25">#25</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-storage-ui">logos-storage-ui</a></h4>
+            <p>Bumped <code>logos-module-builder</code> as needed for QML conflict resolution.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/69">#69</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-view-module-runtime">logos-view-module-runtime</a></h4>
+            <p>Distinguish source-unavailable from invalid response.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-view-module-runtime/pull/16">#16</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-workspace">logos-workspace</a></h4>
+            <p>Pin <code>logos-libp2p-module</code>'s libp2p input to a SHA (deleted upstream branch).</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-workspace/pull/94">#94</a>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <footer>
+        <p>Generated from weekly updates | Logos Collective Roadmap</p>
+      </footer>
+    </div>
+    <script>
+      // Tab switching
+      document.querySelectorAll(".tab").forEach((tab) => {
+        tab.addEventListener("click", () => {
+          const team = tab.dataset.team
+
+          document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"))
+          document.querySelectorAll(".team-content").forEach((c) => c.classList.remove("active"))
+
+          tab.classList.add("active")
+          document.getElementById(team).classList.add("active")
+        })
+      })
+
+      // Milestone toggle
+      function toggleMilestone(header) {
+        const milestone = header.closest(".milestone")
+        milestone.classList.toggle("expanded")
+      }
+
+      // Search functionality
+      const searchInput = document.getElementById("search")
+      searchInput.addEventListener("input", (e) => {
+        const searchTerm = e.target.value.toLowerCase()
+        const allContent = document.querySelectorAll(".milestone, .deliverable, .repo-card")
+
+        allContent.forEach((element) => {
+          const text = element.textContent.toLowerCase()
+          if (text.includes(searchTerm) || searchTerm === "") {
+            element.style.display = ""
+          } else {
+            element.style.display = "none"
+          }
+        })
+      })
+
+      // Keyboard navigation
+      document.addEventListener("keydown", (e) => {
+        if (e.ctrlKey || e.metaKey) {
+          const tabs = Array.from(document.querySelectorAll(".tab"))
+          const activeIndex = tabs.findIndex((t) => t.classList.contains("active"))
+
+          if (e.key === "ArrowLeft" && activeIndex > 0) {
+            e.preventDefault()
+            tabs[activeIndex - 1].click()
+          } else if (e.key === "ArrowRight" && activeIndex < tabs.length - 1) {
+            e.preventDefault()
+            tabs[activeIndex + 1].click()
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/content/reports/weekly/2026-07-20.html
+++ b/content/reports/weekly/2026-07-20.html
@@ -521,16 +521,16 @@
 
       <nav class="week-nav">
         <a class="prev" data-router-ignore href="/reports/weekly/2026-07-13.html">&larr; 2026-07-13</a>
-        <span class="spacer"></span>
+        <a class="next" data-router-ignore href="/reports/weekly/2026-07-27.html">2026-07-27 &rarr;</a>
       </nav>
 
       <div class="stats-bar">
         <div class="stat">
-          <div class="stat-value">4</div>
+          <div class="stat-value">5</div>
           <div class="stat-label">Teams Reporting</div>
         </div>
         <div class="stat">
-          <div class="stat-value">130+</div>
+          <div class="stat-value">175+</div>
           <div class="stat-label">PRs &amp; Updates</div>
         </div>
       </div>
@@ -545,6 +545,14 @@
           <div class="highlight-card messaging">
             <div class="team">Messaging</div>
             <p>Structured API layers plus new <code>logos_delivery_node</code> app with REST API and event observability shipped in <code>logos-delivery</code>.</p>
+          </div>
+          <div class="highlight-card blockchain">
+            <div class="team">Blockchain</div>
+            <p><strong>SDP validator operations</strong> and the <strong>Proof of Claim Groth16 verifier</strong> merged in Nimbos; multi-sequencer committee support landed in the Logos Execution Zone with a convergence demo.</p>
+          </div>
+          <div class="highlight-card blockchain">
+            <div class="team">Blockchain</div>
+            <p>Channel Participation in Proof of Stake finalized &mdash; spec and implementation both ready to merge; total stake inference confirmed at mainnet parameters.</p>
           </div>
           <div class="highlight-card anoncomms">
             <div class="team">AnonComms</div>
@@ -575,6 +583,7 @@
 
       <div class="tabs">
         <button class="tab messaging active" data-team="messaging">Messaging</button>
+        <button class="tab blockchain" data-team="blockchain">Blockchain</button>
         <button class="tab anoncomms" data-team="anoncomms">AnonComms</button>
         <button class="tab storage" data-team="storage">Storage</button>
         <button class="tab logoscore" data-team="logoscore">Logos Core</button>
@@ -793,6 +802,196 @@
                   <li><a href="https://github.com/logos-messaging/nim-ffi/issues/112">Lossless event delivery: unbounded intrusive SPSC queue + node freelist</a></li>
                   <li><a href="https://github.com/logos-messaging/logos-delivery/issues/4033">chore: improve on RLN merkle proof and root refresh logic</a></li>
                   <li><a href="https://github.com/logos-messaging/logos-delivery/pull/4030">Reduce RLN tests duration</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             BLOCKCHAIN
+             ================================================================ -->
+      <div class="team-content" id="blockchain">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Bedrock &mdash; Research</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Mantle</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>SDP Per-Service Uniqueness RFC merged: <code>provider_id</code> and <code>zk_id</code> unique within a service &mdash; <a href="https://github.com/logos-co/logos-lips/pull/371">logos-lips#371</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Cryptarchia</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Channel Participation in Proof of Stake finished the research phase</strong>: RFC ready to merge <a href="https://github.com/logos-co/logos-lips/pull/364">logos-lips#364</a>, implementation accepted (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3145">#3145</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Total Stake Inference</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Mainnet-parameter inference-feedback evaluation completed</strong> (T=388800 slots, f=1/30): block references keep the inferred denominator substantially closer to true stake &mdash; at delays 10/20/29, 0.959/0.882/0.759 of true stake versus 0.705/0.399/0.168 chain-only; at delay 40, chain-only falls to ~0.101 while referenced configurations reach up to ~0.986 &mdash; <a href="https://app.notion.com/p/nomos-tech/Referenced-Block-Visibility-for-Total-Stake-Inference-36a261aa09df8119940dd25205b12f85">doc</a></li>
+                  <li>Additional simulations and figures added to the "Modelling of Network Delays" document &mdash; <a href="https://app.notion.com/p/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Permissionless Channel Sequencing</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Pivot to fully permissionless sequencing: Proposal VIII adopts a public per-channel lottery (new L1 op family, no committee), with a decision map and first-pass withdrawal-exit simulations covering exit-family comparison, lottery weight during pending exits, and concentration windows &mdash; <a href="https://app.notion.com/p/nomos-tech/Permissionless-Channel-Sequencing-Proposal-VIII-3a3261aa09df80168767c7f715fa4f52">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Cross-Zone Sequencing</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Abort Attribution reworked into a commitment-only + challenge-response design following the optimistic fair exchange principle: the happy path registers only hash commitments on-chain, with content disclosed on-chain only when a challenge is opened &mdash; <a href="https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-396261aa09df80f99b7ffcd6ed76e0aa#39d261aa09df8098af6fc62d8b40a8bc">doc</a></li>
+                  <li>Intent structure and hash computation fixed: canonical <code>CrossZoneIntent</code> serialization with SHA-256 commitments, so <code>proposal_id = H(intent)</code> serves as an openable commitment in disputes &mdash; <a href="https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-396261aa09df80f99b7ffcd6ed76e0aa#39d261aa09df8098af6fc62d8b40a8bc">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Anonymous Communications</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Bayesian sender-attribution attack built, completing the anonymity axis alongside stake inference, with three unlinkability measures: top-1 de-anonymisation, mean true-sender posterior, and posterior entropy &mdash; <a href="https://app.notion.com/p/nomos-tech/Bayesian-sender-attribution-attack-trilemma-and-the-experimental-framework-with-the-single-path-mi-87e261aa09df838e80bb01eb6f358bb1">doc</a>, <a href="https://app.notion.com/p/nomos-tech/Bayesian-Sender-Attribution-Attack-and-the-Three-Unlinkability-Measures-3a6261aa09df80f5a465ee7461021082">doc</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Bedrock &mdash; Engineering</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Blend</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Connectivity maintenance design rewritten for simplicity (WIP) &mdash; <a href="https://app.notion.com/p/nomos-tech/WIP-Connectivity-Maintenance-readable-rewrite-107d88825f9f4d19beffafbaaa69ba86">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Node</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Initial Block Download fix: <code>AlreadyApplied</code> errors ignored to handle the overlapped part of the chain &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3126">#3126</a></li>
+                  <li>Devnet validation completed: Initial Block Download, SDP no-garbage-collection behavior, service rewards distribution, and Tokenomics fees confirmed working as intended</li>
+                  <li>Channel thresholds accounted for in gas costs merged <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3118">#3118</a>; priority tip on the fund endpoint merged <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3116">#3116</a></li>
+                  <li>SDP snapshot API endpoint added <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3132">#3132</a>; SDP declarations returned keyed by id <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3133">#3133</a>; <code>discovered_peers</code> on <code>/network/info</code> (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3135">#3135</a></li>
+                  <li>Recovery state moving to RocksDB (in-review): Overwatch runtime handle for state operators <a href="https://github.com/logos-co/Overwatch/pull/142">Overwatch#142</a>, node recovery state <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3134">#3134</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Testing</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Testing Framework merged: snapshot store support <a href="https://github.com/logos-blockchain/logos-blockchain-testing/pull/56">logos-blockchain-testing#56</a>, multiple apps in one test stack <a href="https://github.com/logos-blockchain/logos-blockchain-testing/pull/57">#57</a>, unified cluster provisioning for scenarios, app deployments, and manual clusters <a href="https://github.com/logos-blockchain/logos-blockchain-testing/pull/58">#58</a></li>
+                  <li>Tokio-console profiling: cucumber integration <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3129">#3129</a> and console-subscriber update <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3136">#3136</a> merged, opt-in task naming in Overwatch <a href="https://github.com/logos-co/Overwatch/pull/141">Overwatch#141</a>; Overwatch bump for tokio-console (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3148">#3148</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Zone SDK</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Channel-update transactions unified with custom transactions merged &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3122">#3122</a></li>
+                  <li>L1 op identity and finalized slot surfaced on channel messages (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3147">#3147</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Logos Core Integration</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Node 0.2.1-rc.2 pre-release published &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/releases/tag/0.2.1-rc.2">release</a>, with module release steps added to the release checklist <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3112">#3112</a></li>
+                  <li>Module join-blend fix merged <a href="https://github.com/logos-blockchain/logos-blockchain-module/pull/53">logos-blockchain-module#53</a>; explorer tab with copyable fields merged in the dashboard UI <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/33">logos-blockchain-ui#33</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Execution Zone (LEZ)</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Wallet UI</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Wallet synchronization flow rework merged &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/585">#585</a></li>
+                  <li>PDA account-id generation in the wallet FFI merged &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/582">#582</a></li>
+                  <li>Batched merkle proof fetching merged &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/598">#598</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Sequencer</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Multi-sequencer committee support merged</strong> with <code>adminConfigureChannel</code> and a convergence demo &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/616">#616</a></li>
+                  <li>Request distribution across multiple sequencers opened (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/623">#623</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Accounts</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>View-tag randomization for updated accounts (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/591">#591</a></li>
+                  <li>Dummy-note padding via random seeding of nullifiers and commitments (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/592">#592</a>; ciphertext padding, which closes the last large privacy leak (the ciphertext size), opened (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/630">#630</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Cross-Zone</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Programs deployed at genesis instead of builtins (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/615">#615</a></li>
+                  <li>Cross-zone generalization directions written up for team decisions &mdash; <a href="https://app.notion.com/p/Directions-to-agree-with-the-team-39f8f96fb65c80ada3acf18d3e16a7b2">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Refactor</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>CI sped up with a prebuilt docker image caching dependencies &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/618">#618</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Nimbos</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Nimbos</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>SDP validator operations merged</strong>: declare/withdraw/active ops wired into the ledger, with registry, query API, and tests &mdash; <a href="https://github.com/logos-co/nimbos/pull/111">nimbos#111</a></li>
+                  <li><strong>Proof of Claim Groth16 verifier merged</strong>, with shared verification-key helpers and circuit/fixture tests &mdash; <a href="https://github.com/logos-co/nimbos/pull/120">nimbos#120</a></li>
+                  <li>SDP module layout refactored to honour layering rules &mdash; <a href="https://github.com/logos-co/nimbos/pull/128">nimbos#128</a></li>
+                  <li>Epoch state management (in-review) &mdash; <a href="https://github.com/logos-co/nimbos/pull/126">nimbos#126</a></li>
+                  <li>Anonymous Leaders Reward Protocol ledger state and claim path opened (in-review) &mdash; <a href="https://github.com/logos-co/nimbos/pull/134">nimbos#134</a></li>
+                  <li>SDP epoch snapshot mapping fixed to n+2 (in-review) <a href="https://github.com/logos-co/nimbos/pull/136">nimbos#136</a>; non-mutating SDP/channel state transitions via sink parameters (in-review) <a href="https://github.com/logos-co/nimbos/pull/137">nimbos#137</a></li>
+                  <li>End-to-end Initial Block Download tested against a local Rust network</li>
                 </ul>
               </div>
             </div>

--- a/content/reports/weekly/2026-07-27.html
+++ b/content/reports/weekly/2026-07-27.html
@@ -1,0 +1,1588 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logos Collective Weekly Summary - Week 30, 2026</title>
+    <style>
+      :root {
+        --bg-primary: #0d1117;
+        --bg-secondary: #161b22;
+        --bg-tertiary: #21262d;
+        --text-primary: #f0f6fc;
+        --text-secondary: #8b949e;
+        --border-color: #30363d;
+        --accent-storage: #3fb950;
+        --accent-messaging: #58a6ff;
+        --accent-logoscore: #a371f7;
+        --accent-blockchain: #f78166;
+        --accent-anoncomms: #d2a8ff;
+        --highlight-bg: rgba(56, 139, 253, 0.15);
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial,
+          sans-serif;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        line-height: 1.6;
+        min-height: 100vh;
+      }
+
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem;
+      }
+
+      header {
+        text-align: center;
+        margin-bottom: 3rem;
+        padding-bottom: 2rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      header h1 {
+        font-size: 2.5rem;
+        margin-bottom: 0.5rem;
+        background: linear-gradient(135deg, #58a6ff, #a371f7);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+
+      header .date {
+        color: var(--text-secondary);
+        font-size: 1.1rem;
+      }
+
+      .highlights-section {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        padding: 2rem;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .highlights-section h2 {
+        margin-bottom: 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .highlights-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+      }
+
+      .highlight-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        border-left: 4px solid;
+        transition:
+          transform 0.2s,
+          box-shadow 0.2s;
+      }
+
+      .highlight-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      .highlight-card.storage {
+        border-left-color: var(--accent-storage);
+      }
+      .highlight-card.messaging {
+        border-left-color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore {
+        border-left-color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain {
+        border-left-color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms {
+        border-left-color: var(--accent-anoncomms);
+      }
+
+      .highlight-card .team {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.5rem;
+        opacity: 0.8;
+      }
+
+      .highlight-card.storage .team {
+        color: var(--accent-storage);
+      }
+      .highlight-card.messaging .team {
+        color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore .team {
+        color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain .team {
+        color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms .team {
+        color: var(--accent-anoncomms);
+      }
+
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+      }
+
+      .tab {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: all 0.2s;
+        border: 1px solid var(--border-color);
+      }
+
+      .tab:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+      }
+
+      .tab.active {
+        color: var(--text-primary);
+      }
+
+      .tab.active.storage {
+        background: var(--accent-storage);
+        color: #000;
+      }
+      .tab.active.messaging {
+        background: var(--accent-messaging);
+        color: #000;
+      }
+      .tab.active.logoscore {
+        background: var(--accent-logoscore);
+        color: #000;
+      }
+      .tab.active.blockchain {
+        background: var(--accent-blockchain);
+        color: #000;
+      }
+      .tab.active.anoncomms {
+        background: var(--accent-anoncomms);
+        color: #000;
+      }
+
+      .team-content {
+        display: none;
+        animation: fadeIn 0.3s ease;
+      }
+
+      .team-content.active {
+        display: block;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      .milestone {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 1.5rem;
+        border: 1px solid var(--border-color);
+        overflow: hidden;
+      }
+
+      .milestone-header {
+        padding: 1rem 1.5rem;
+        background: var(--bg-tertiary);
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        user-select: none;
+      }
+
+      .milestone-header:hover {
+        background: rgba(48, 54, 61, 0.8);
+      }
+
+      .milestone-header h3 {
+        font-size: 1.1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .milestone-header h3 a {
+        color: var(--text-primary);
+        text-decoration: none;
+      }
+
+      .milestone-header h3 a:hover {
+        text-decoration: underline;
+      }
+
+      .milestone-toggle {
+        font-size: 1.5rem;
+        color: var(--text-secondary);
+        transition: transform 0.3s;
+      }
+
+      .milestone.expanded .milestone-toggle {
+        transform: rotate(180deg);
+      }
+
+      .milestone-body {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease;
+      }
+
+      .milestone.expanded .milestone-body {
+        max-height: 5000px;
+      }
+
+      .milestone-content {
+        padding: 1.5rem;
+      }
+
+      .deliverable {
+        margin-bottom: 1.5rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .deliverable:last-child {
+        margin-bottom: 0;
+        padding-bottom: 0;
+        border-bottom: none;
+      }
+
+      .deliverable h4 {
+        font-size: 1rem;
+        margin-bottom: 1rem;
+        color: var(--text-primary);
+      }
+
+      .deliverable h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .deliverable h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .section-label {
+        display: inline-block;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        margin-bottom: 0.5rem;
+      }
+
+      .section-label.achieved {
+        background: rgba(63, 185, 80, 0.2);
+        color: var(--accent-storage);
+      }
+
+      .section-label.next {
+        background: rgba(88, 166, 255, 0.2);
+        color: var(--accent-messaging);
+      }
+
+      .section-label.blockers {
+        background: rgba(247, 129, 102, 0.2);
+        color: var(--accent-blockchain);
+      }
+
+      .item-list {
+        list-style: none;
+        margin-left: 0;
+      }
+
+      .item-list li {
+        padding: 0.5rem 0;
+        padding-left: 1.5rem;
+        position: relative;
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+      }
+
+      .item-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.85rem;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--text-secondary);
+      }
+
+      .item-list li a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .item-list li a:hover {
+        text-decoration: underline;
+      }
+
+      .stats-bar {
+        display: flex;
+        gap: 2rem;
+        padding: 1rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+      }
+
+      .stat {
+        text-align: center;
+      }
+
+      .stat-value {
+        font-size: 2rem;
+        font-weight: 700;
+      }
+
+      .stat-label {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .repo-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 1rem;
+      }
+
+      .repo-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .repo-card h4 {
+        font-size: 0.95rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .repo-card h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .repo-card h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .repo-card p {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .pr-list {
+        margin-top: 0.5rem;
+      }
+
+      .pr-list a {
+        display: inline-block;
+        font-size: 0.8rem;
+        color: #58a6ff;
+        margin-right: 0.5rem;
+        text-decoration: none;
+      }
+
+      .pr-list a:hover {
+        text-decoration: underline;
+      }
+
+      .search-box {
+        margin-bottom: 1.5rem;
+      }
+
+      .search-box input {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+
+      .search-box input::placeholder {
+        color: var(--text-secondary);
+      }
+
+      .search-box input:focus {
+        outline: none;
+        border-color: #58a6ff;
+        box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.2);
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      footer {
+        text-align: center;
+        padding: 2rem;
+        color: var(--text-secondary);
+        border-top: 1px solid var(--border-color);
+        margin-top: 3rem;
+      }
+
+      @media (max-width: 768px) {
+        .container {
+          padding: 1rem;
+        }
+
+        header h1 {
+          font-size: 1.75rem;
+        }
+
+        .stats-bar {
+          justify-content: space-around;
+        }
+
+        .stat-value {
+          font-size: 1.5rem;
+        }
+      }
+      /* week-nav-css */
+      .week-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+        padding: 0.75rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .week-nav a {
+        color: var(--text-primary);
+        text-decoration: none;
+        padding: 0.5rem 1rem;
+        border-radius: 8px;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: background 0.2s;
+      }
+      .week-nav a:hover {
+        background: var(--bg-tertiary);
+      }
+      .week-nav .prev { margin-right: auto; }
+      .week-nav .next { margin-left: auto; }
+      .week-nav .spacer { flex: 1; }
+      /* /week-nav-css */
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Logos Collective Weekly Summary</h1>
+        <p class="date">Week 30, 2026 (July 27, 2026)</p>
+      </header>
+
+      <nav class="week-nav">
+        <a class="prev" data-router-ignore href="/reports/weekly/2026-07-20.html">&larr; 2026-07-20</a>
+        <a class="next" data-router-ignore href="/reports/weekly/2026-08-03.html">2026-08-03 &rarr;</a>
+      </nav>
+
+      <div class="stats-bar">
+        <div class="stat">
+          <div class="stat-value">5</div>
+          <div class="stat-label">Teams Reporting</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">225+</div>
+          <div class="stat-label">PRs &amp; Updates</div>
+        </div>
+      </div>
+
+      <section class="highlights-section">
+        <h2>Key Highlights</h2>
+        <div class="highlights-grid">
+          <div class="highlight-card messaging">
+            <div class="team">Messaging</div>
+            <p>In-repo API/e2e test suite landed in <code>logos-delivery</code>, with a docker subset wired into CI and the rate-limit manager moved to the messaging client layer.</p>
+          </div>
+          <div class="highlight-card blockchain">
+            <div class="team">Blockchain</div>
+            <p><strong>Channel Participation in Proof of Stake LIP merged</strong> &mdash; spec <a href="https://github.com/logos-co/logos-lips/pull/364">logos-lips#364</a> and implementation <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3145">#3145</a>.</p>
+          </div>
+          <div class="highlight-card blockchain">
+            <div class="team">Blockchain</div>
+            <p><strong>Multi-sequencer support merged across the Logos Execution Zone stack</strong>; Post-Quantum Safety Analysis of the Bedrock layer finalized.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p><strong>Oracle mechanism specification published as a LIP</strong>, laying the groundwork for the Decentralised Oracle Network.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p>Mix-based chat with DoS protection presented and demoed at the <a href="https://www.youtube.com/watch?v=6TRcUIYt_wE&amp;list=PLZe53tXAogqNiGROz9NvxTJ251sK1TiLH&amp;index=1">IFT Town Hall</a>.</p>
+          </div>
+          <div class="highlight-card storage">
+            <div class="team">Storage</div>
+            <p>Three path-selection simulations from the "When Mixnets Fail" paper implemented in <code>hs-mix-sim</code>; new storage docs plan completed.</p>
+          </div>
+          <div class="highlight-card logoscore">
+            <div class="team">Logos Core</div>
+            <p>Multi-user daemon support landed: group-shareable local sockets, operator-issued token enforcement on <code>core_service</code>, and a transport-aware token validator across the protocol stack.</p>
+          </div>
+        </div>
+      </section>
+
+      <div class="search-box">
+        <input
+          type="text"
+          id="search"
+          placeholder="Search updates (e.g., 'RLN', 'QUIC', 'sequencer', 'oracle', 'token validator')..."
+        />
+      </div>
+
+      <div class="tabs">
+        <button class="tab messaging active" data-team="messaging">Messaging</button>
+        <button class="tab blockchain" data-team="blockchain">Blockchain</button>
+        <button class="tab anoncomms" data-team="anoncomms">AnonComms</button>
+        <button class="tab storage" data-team="storage">Storage</button>
+        <button class="tab logoscore" data-team="logoscore">Logos Core</button>
+      </div>
+
+      <!-- ================================================================
+             MESSAGING
+             ================================================================ -->
+      <div class="team-content active" id="messaging">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Messaging API &mdash; General Availability</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/429">Reliability and scale validation with DST</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Separate binary created to allow DST to test the messaging-client API &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4005">#4005</a></li>
+                  <li>Artifact builds and uploads adjusted to contain the <code>logosdeliverynode</code> app &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4059">#4059</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Add <code>logosdeliverynode</code> docker-compose stack &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4057">#4057</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Test suite for Messaging API</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>In-repo API/e2e test suite added</strong> (<code>tests-e2e</code>) &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4027">#4027</a></li>
+                  <li>Docker subset of the API/e2e wrapper tests running in CI &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4052">#4052</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Port remaining wrapper tests from the interop repo &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4077">#4077</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/431">Create Rate Limit Manager</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Rate-limit manager moved to the messaging client layer &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4021">#4021</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Enforce the per-epoch rate limit at the send service (RLN-sourced) &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4062">#4062</a></li>
+                  <li>Attach and refresh RLN proofs in the send service (Stream B) &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4069">#4069</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Reliable Channel API &mdash; Beta</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Reliable Channel API stabilization and bug fixes</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Channels default to unencrypted so messages flow &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4051">#4051</a></li>
+                  <li>Wire sender's id now reported in <code>channel_message_received</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4073">#4073</a></li>
+                  <li>E2E tests: RC05/RC06 Reliable Channel test variants &mdash; <a href="https://github.com/logos-messaging/logos-delivery-interop-tests/pull/200">logos-delivery-interop-tests#200</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Stop emitting receive events after <code>channel_close</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4075">#4075</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Support QUIC Transport in Logos Delivery</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/324">Trial QUIC</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>QUIC dialled before TCP regardless of address list order &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4061">#4061</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Bump <code>nim-lsquic</code> v0.5.1 &rarr; v0.5.6 &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4055">#4055</a></li>
+                  <li>Bump <code>libp2p</code> v2.2.0 &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4060">#4060</a></li>
+                  <li>DST scale validation of QUIC transport &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/3986">#3986</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Fleet Stability</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/382">Fleet monitoring dashboards for Logos fleets</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Sonda metrics grouped and simplified &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4040">#4040</a></li>
+                  <li>Error label of <code>failed_store_queries</code> bounded &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4053">#4053</a></li>
+                  <li>Every metric given a <code>logos_delivery_</code> prefix &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4074">#4074</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Sync dashboards from Grafana &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4079">#4079</a></li>
+                  <li>Update infra-logos dashboards and alerts to the new <code>logos_delivery_</code> metric prefix</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/384">Resolve known fleet stability issues</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Bump <code>nim-libp2p</code> to v2.2.0 and replace <code>nat_traversal</code> with libp2p <code>NATConfig</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4041">#4041</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Chat &mdash; Beta</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/439">Implement full identity model</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Key bundles and accounts published via Logos Delivery &mdash; <a href="https://github.com/logos-messaging/libchat/pull/184">libchat#184</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/440">Stabilize and polish API</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>List Participants in DirectV1 &mdash; <a href="https://github.com/logos-messaging/libchat/pull/189">libchat#189</a></li>
+                  <li>HNDL protections enabled &mdash; <a href="https://github.com/logos-messaging/libchat/pull/193">libchat#193</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Core Integration &mdash; Phase 2</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/388">Add Reliable Channel API to Logos Core Delivery module</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Reliable Channels API support added &mdash; <a href="https://github.com/logos-co/logos-delivery-module/pull/68">logos-delivery-module#68</a></li>
+                  <li>Store queries exposed via <code>storeQuery</code> &mdash; <a href="https://github.com/logos-co/logos-delivery-module/pull/76">logos-delivery-module#76</a></li>
+                  <li>Node data stored under the module's per-instance path &mdash; <a href="https://github.com/logos-co/logos-delivery-module/pull/72">logos-delivery-module#72</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Release <code>logos-delivery-module</code> v0.2.0 &mdash; <a href="https://github.com/logos-co/logos-delivery-module/pull/75">logos-delivery-module#75</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Maintenance</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>nim-ffi</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>0.2 line integrated into master: <code>{.ffi.}</code> shape router, <code>{.ffiExport.}</code>, context recycling &mdash; <a href="https://github.com/logos-messaging/nim-ffi/pull/142">nim-ffi#142</a></li>
+                  <li><code>{.ffiConst.}</code> constants and <code>{.ffi.}</code> enums for C/C++/Rust &mdash; <a href="https://github.com/logos-messaging/nim-ffi/pull/140">nim-ffi#140</a></li>
+                  <li><code>{.ffiStatic.}</code> for context-independent procs &mdash; <a href="https://github.com/logos-messaging/nim-ffi/pull/138">nim-ffi#138</a></li>
+                  <li>CBOR-free transport for non-scalar <code>abi = c</code> procs &mdash; <a href="https://github.com/logos-messaging/nim-ffi/pull/137">nim-ffi#137</a></li>
+                  <li><code>seq[byte]</code> rides as a CBOR byte string on every backend &mdash; <a href="https://github.com/logos-messaging/nim-ffi/pull/141">nim-ffi#141</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Logos Delivery</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><code>nim-brokers</code> bumped to 3.3.0 with a nim-brokers skill added &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4058">#4058</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Bump <code>nim-ffi</code> to 0.3.0 (per-listener event ABI) &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4070">#4070</a></li>
+                  <li>Replace <code>minprotobuf</code> with <code>nim-protobuf-serialization</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4046">#4046</a></li>
+                  <li>Nocopy message path PoC: <a href="https://github.com/logos-messaging/logos-delivery/pull/4036">1/3 perf harness</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4037">2/3 WakuMessage as ref object</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4038">3/3 WakuEnvelope decode once</a></li>
+                  <li>Pull and publish the Logos Attic cache in nix builds &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4071">#4071</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             BLOCKCHAIN
+             ================================================================ -->
+      <div class="team-content" id="blockchain">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Bedrock &mdash; Research</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Cryptarchia</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Channel Participation in Proof of Stake merged</strong>: spec <a href="https://github.com/logos-co/logos-lips/pull/364">logos-lips#364</a> and implementation <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3145">#3145</a></li>
+                  <li>Fast Bootstrapping RFC passed the research phase <a href="https://github.com/logos-co/logos-lips/pull/368">logos-lips#368</a>; blake2b dynamic merkle tree opened toward its implementation (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3174">#3174</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Post-Quantum</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Post-Quantum Safety Analysis of the Logos Bedrock Layer finalized</strong> &mdash; <a href="https://app.notion.com/p/nomos-tech/Post-Quantum-Safety-Analysis-of-the-Logos-Bedrock-Layer-360261aa09df80a6a98dc4d787cfa499">doc</a></li>
+                  <li>Post-Quantum ZK Transition Paths written up from the cross-scheme benchmark results &mdash; <a href="https://app.notion.com/p/nomos-tech/Post-Quantum-ZK-Transition-Paths-39c261aa09df8049872cdfc7ab1eb0e8">doc</a></li>
+                  <li>Benchmark implementation extended with Rust and aws-lc-rs libraries (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain-pocs/pull/112">logos-blockchain-pocs#112</a>; benchmark dashboard updated &mdash; <a href="https://megonen.github.io/pq-bench-rpi5/">dashboard</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Total Stake Inference</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>"Modelling of Network Delays" <a href="https://app.notion.com/p/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0">doc</a> and "Total Stake Inference with Network Delays" <a href="https://app.notion.com/p/nomos-tech/Total-Stake-Inference-with-Network-Delays-372261aa09df82188afd01720e33a79c">doc</a> revised</li>
+                  <li>Total Stake Inference with uncle references: simulation results promising, with further runs planned to explore the parameter space and ensure equilibration &mdash; <a href="https://app.notion.com/p/nomos-tech/Referenced-Block-Visibility-for-Total-Stake-Inference-36a261aa09df8119940dd25205b12f85#39c261aa09df80e1a2e2d380a5a385c7">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Permissionless Channel Sequencing</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Channel lottery fully specified and made executable: reference implementation plus adversary-in-the-loop simulations covering exit-freeze end-to-end, mass-exit drain, and stall succession &mdash; <a href="https://app.notion.com/p/nomos-tech/Permissionless-Channel-Sequencing-Channel-Lottery-3ab261aa09df8041928ce10c0ad15cc3">doc</a></li>
+                  <li>Proposal VIII revised against a survey of the academic and industry literature; substrate refreshed to Mantle v1.9.0 &mdash; <a href="https://app.notion.com/p/nomos-tech/Permissionless-Channel-Sequencing-Proposal-VIII-3ab261aa09df80eea54cdcdfeb30a115">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Anonymous Communications</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Single-path mix model completed under both uniform and geography-calibrated latency laws (continent mixture calibrated to real inter-city pings), with anonymity-latency-bandwidth trilemma plots &mdash; <a href="https://app.notion.com/p/nomos-tech/Single-Path-Mix-Model-Complete-Uniform-Geo-the-Trilemma-Plots-c42261aa09df835d856401f5e4fa48a6">doc</a></li>
+                  <li>Single-path Bayesian traffic analysis completed for both latency models, extending sender attribution with the geographic latency model &mdash; <a href="https://app.notion.com/p/nomos-tech/Single-Path-Mix-Model-Uniform-and-Geographic-Latency-the-Trilemma-Plots-3a9261aa09df80119d06f797e00da34e">doc</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Bedrock &mdash; Engineering</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Security Audit</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Bounded-type hardening continued: op-proof vectors <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3150">#3150</a>, SDP declarations in the genesis block <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3157">#3157</a>, exact-size zk verifier JSON input <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3167">#3167</a>, block proposal references <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3170">#3170</a>, and wallet block transformations <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3175">#3175</a> merged; bounded, validated merkle paths (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3183">#3183</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Node</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Transactions revamped into a verification typestate</strong>: verification state tracked at compile time, moving operation verification out of the ledger <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3123">#3123</a>; transaction traits refactored <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3168">#3168</a> and the tx module decomposed <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3169">#3169</a>; stateless/stateful op verification split (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3185">#3185</a></li>
+                  <li>SDP <code>provider_id</code> and <code>zk_id</code> uniqueness enforced within a service <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3102">#3102</a>, implementing the Per-Service Uniqueness RFC</li>
+                  <li>Wallet updated for channel participation in Proof of Stake: deposited notes kept with <code>ChannelTransfer</code>/<code>ChannelWithdraw</code> tracking <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3149">#3149</a>, leadership participation with output notes <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3151">#3151</a>, ownership of withdrawn notes <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3152">#3152</a></li>
+                  <li>Chain-service main event loop reorganized into phases <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3162">#3162</a>; blend readiness no longer awaited via timeout <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3158">#3158</a></li>
+                  <li>Recovery state migrated to RocksDB: node state <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3134">#3134</a> and remaining services <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3159">#3159</a> merged, on top of the Overwatch runtime-handle support <a href="https://github.com/logos-co/Overwatch/pull/142">Overwatch#142</a></li>
+                  <li>Execution market: storage gas consumption now accumulated <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3181">#3181</a>; spec base-fee fix based on <code>G_target</code> (in-review) <a href="https://github.com/logos-co/logos-lips/pull/380">logos-lips#380</a></li>
+                  <li>Dynamic merkle tree extracted and generalized <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3164">#3164</a>; UTXOs exposed on transfer operations <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3163">#3163</a>; genesis block root validated on deserialize (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3161">#3161</a></li>
+                  <li>API consistency: structured JSON error bodies merged <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3182">#3182</a>; centralized typed HTTP errors (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3172">#3172</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Testing</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Tokio-console profiling: Overwatch bump merged <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3148">#3148</a>, task names and raw recording added <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3165">#3165</a></li>
+                  <li>Heavy CI moved to a merge queue <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3176">#3176</a>, <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3184">#3184</a></li>
+                  <li>Flaky block-streaming test fixed: genesis time was computed too early &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3178">#3178</a></li>
+                  <li>Wallet-scanner recovery from reorged snapshot seed tips (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3180">#3180</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Zone SDK</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>L1 op identity and finalized slot surfaced on channel messages merged &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3147">#3147</a></li>
+                  <li>Backfilling fixed: gap-backfilled inscriptions now surface as adopted, with an additional fix for orphaned finalized transactions (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3079">#3079</a></li>
+                  <li>C bindings implement the full <code>Node</code> interface, a prerequisite for a switchable API backend for the zone SDK (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3173">#3173</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Logos Core Integration</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Dashboard UI fixes merged: resume on the node view when a config exists <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/40">logos-blockchain-ui#40</a>, long config paths elided <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/43">logos-blockchain-ui#43</a>; backoff strategy for status polling (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/45">logos-blockchain-ui#45</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Execution Zone (LEZ)</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Sequencer</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Multi-sequencer wallet client merged</strong> <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/600">#600</a>, with request distribution across multiple sequencers <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/623">#623</a>; client parallelism (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/638">#638</a></li>
+                  <li>Common two-tip chain state for decentralized sequencing merged across indexer and sequencer &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/603">#603</a></li>
+                  <li>Sequencer state bootstraps from Bedrock &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/606">#606</a></li>
+                  <li>Decentralized-sequencing Sprint 2 scoped and planned <a href="https://app.notion.com/p/Sprint-2-3988f96fb65c805687b6dcec7b0f91ea">doc</a>; follow-up fixes opened (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/642">#642</a></li>
+                  <li>Multi-sequencer support for integration tests (WIP, draft) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/643">#643</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Accounts</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>View-tag randomization for updated accounts merged &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/591">#591</a></li>
+                  <li>Public transactions that silently drop a deposit are rejected <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/625">#625</a>; <code>PrivateUnauthorized</code> authorization corrected <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/621">#621</a></li>
+                  <li>Dummy-note padding via random seeding of nullifiers and commitments (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/592">#592</a>; ciphertext padding (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/630">#630</a></li>
+                  <li>Design of the authorization mechanism for private accounts written up &mdash; <a href="https://hackmd.io/@tgReoUp4TR6_bM3e22EdBQ/SkVkPzNQzl">doc</a></li>
+                  <li>Private/public environment unification: aligning code and design decisions so semantics do not differ between private and public state (WIP) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/compare/dev...artem/lee-environment-unification">branch</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Wallet UI</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Signing with recipient keys dropped <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/594">#594</a>; change-network command added <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/596">#596</a></li>
+                  <li>Wallet UI: LEZ module renaming merged <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/27">logos-execution-zone-wallet-ui#27</a>; public-account initialize button (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/28">#28</a>; account labels <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/29">#29</a> and improved private-account listing <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/30">#30</a> opened (in-review); mnemonic recovery (WIP, draft) <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/31">#31</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Cross-Zone</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Programs deployed at genesis instead of builtins merged &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/615">#615</a></li>
+                  <li>Cross-zone generalization Phase 0 planned, with 2-3 PRs scoped &mdash; <a href="https://app.notion.com/p/General-plan-3a68f96fb65c804eae7ace34befcecc3">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Keycard</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Migration from keycard-py to keycard-rs merged in the keycard wallet &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/595">#595</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Nimbos</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Nimbos</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Epoch state management merged &mdash; <a href="https://github.com/logos-co/nimbos/pull/126">nimbos#126</a></li>
+                  <li>SDP epoch snapshot mapping fixed to n+2 <a href="https://github.com/logos-co/nimbos/pull/136">nimbos#136</a>; non-mutating SDP/channel state transitions via sink parameters <a href="https://github.com/logos-co/nimbos/pull/137">nimbos#137</a></li>
+                  <li>Gas metering opened (in-review) &mdash; <a href="https://github.com/logos-co/nimbos/pull/149">nimbos#149</a></li>
+                  <li>Block body validation <a href="https://github.com/logos-co/nimbos/pull/142">nimbos#142</a> and block proposal spec <a href="https://github.com/logos-co/nimbos/pull/143">nimbos#143</a> opened (WIP)</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             ANONCOMMS
+             ================================================================ -->
+      <div class="team-content" id="anoncomms">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Create a basic service discovery module</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/36">Validate service discovery protocol correctness in large-scale simulations</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Kademlia retry logic fixed &mdash; <a href="https://github.com/vacp2p/nim-libp2p/pull/2865">nim-libp2p#2865</a></li>
+                  <li>Closed a gap where service discovery's per-service routing tables accepted peers straight from REGISTER/GET_ADS senders and gossiped <code>closerPeers</code>, without the address-policy/IP-diversity checks the main Kad-DHT table already enforced &mdash; <a href="https://github.com/vacp2p/nim-libp2p/pull/2870">nim-libp2p#2870</a></li>
+                  <li>RFC spec work &mdash; <a href="https://github.com/logos-co/logos-lips/pull/377">logos-lips#377</a></li>
+                  <li>PR reviews and discussions on protocol correctness; <strong>a protocol flaw was discovered during analysis</strong></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Continue further investigations and analysis on protocol correctness</li>
+                  <li>Fix the discovered protocol flaw</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Establish libp2p mixnet</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/51">Research more advanced cover traffic generation techniques</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>libp2p <a href="https://github.com/logos-co/nim-libp2p-mix/pull/32">version bumped</a> in mix, and nimble <a href="https://github.com/logos-co/nim-libp2p-mix/pull/33">issues</a> addressed</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Fix a possible <a href="https://github.com/logos-co/nim-libp2p-mix/issues/19">leak</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/52">Implement local reputation mechanism and research advanced DoS protection</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Mix-based chat presented at the <a href="https://www.youtube.com/watch?v=6TRcUIYt_wE&amp;list=PLZe53tXAogqNiGROz9NvxTJ251sK1TiLH&amp;index=1">IFT Town Hall</a></strong></li>
+                  <li>Explored and compared candidate non-RLN DoS schemes against the current RLN approach (precompute and slashing variants, plus the Dynark optimisation) (WIP)</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Finalise the comparison document and the non-RLN DoS research note</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Deliver de-MLS for p2p group messaging</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/62">Implementing recovery mode</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>All liveness timers moved outside de-MLS, allowing the libchat side to choose how, when, and by whom to react when something goes wrong, or when the group needs adjusting to a concrete policy</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/63">Integrating de-MLS into libchat</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Public API added that allows creating a group with members</li>
+                  <li>Simple version of the integration policy implemented</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Finish the libchat PR</li>
+                  <li>Start working on a new <a href="https://github.com/vacp2p/de-mls/issues/136">issue</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Implement RLN membership allocation service</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/79">Implement basic RLN membership management module</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Registration via the membership allocation protocol implemented</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Implement functions for proof generation, proof verification, and rate limit budget</li>
+                  <li>Align with the latest spec</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/82">Research advanced authentication techniques for RLN membership allocation</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Keycard device certificate used as an authentication mechanism</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Decentralised Oracle Network</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/56">Specifying oracle mechanism</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>The <a href="https://lip.logos.co/anoncomms/raw/logos-oracle-zone.html">oracle mechanism specification</a> is now published as a LIP</strong>; feedback addressed and the oracle mechanism <a href="https://github.com/logos-co/logos-lips/pull/366">PR</a> merged</li>
+                  <li>Oracle mechanism PR reviewed; a <a href="https://github.com/sydhds/logos_oracle_network/tree/main">Logos Oracle Network implementation</a> started</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Follow-up PR including the indexer proposer mechanism</li>
+                  <li>Continue work on the Logos Oracle Network implementation</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Maintain and expand Zerokit</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/60">Release Zerokit (v3.0.0) with enum-based runtime configuration</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Zerokit refactor completed (<a href="https://github.com/vacp2p/zerokit/pull/425">PR14</a>), now reviewed and close to being merged</li>
+                  <li>zerokit-api docs <a href="https://github.com/logos-co/logos-lips/pull/378">PR</a> merged after review</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Merge PR14 and release v3.0.0</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             STORAGE
+             ================================================================ -->
+      <div class="team-content" id="storage">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Mix Transport</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Mix Transport</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Mix learning resources compiled together &mdash; <a href="https://hackmd.io/D5zg08cWSe28oJzXxftFLQ">notes</a></li>
+                  <li><strong>Mix build system made more predictable</strong> (Nimble SAT solver behavior), groundwork for the upcoming Mix transport layer &mdash; <a href="https://github.com/logos-co/nim-libp2p-mix/pull/33">nim-libp2p-mix#33</a></li>
+                  <li>Discussed options and requirements to have something demonstrable as quickly as possible</li>
+                  <li>Discussed the de-anonymization issue</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/20">Hidden Services Over Mix</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Path selection and the malicious path problem</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Studied and experimented with the different path-selection strategies from <a href="https://www.ndss-symposium.org/wp-content/uploads/2026-f2384-paper.pdf">When Mixnets Fail</a>, giving more insight into the malicious path problem and possible solutions to limit it for both the anonymous download and hidden services settings</li>
+                  <li><strong>Three path-selection strategies from the paper simulated</strong> in the <a href="https://github.com/logos-storage/hs-mix-sim">free-route mix simulator</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Study/experiment further with the path selection strategies, especially for the planned anonymous download and transport layer setting</li>
+                  <li>Work on a proposal for a path selection strategy for anonymous download to limit the malicious path problem</li>
+                  <li>Long term: investigate how these can possibly be extended and applied in the hidden services setting</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/9">Switch to Kad-DHT</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Switch to Kad-DHT</h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Evaluate replacing the discv5 DHT with libp2p's Kademlia DHT</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Storage Documentation</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Storage Documentation</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Quartz plugin updated for the web view of the Logos Storage Obsidian vault &mdash; <a href="https://logos-storage.github.io/logos-storage-docs-obsidian/">site</a></li>
+                  <li><strong>Plans for the new storage docs completed</strong>: continued specification of a generic API reference documentation generator, along with Logos Storage documentation migration &mdash; <a href="https://hackmd.io/@codex-storage/rJNzTdOQzl">plan</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             LOGOS CORE
+             ================================================================ -->
+      <div class="team-content" id="logoscore">
+        <div class="repo-list">
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-basecamp">logos-basecamp</a></h4>
+            <p>Design system cache fix on new releases, consistent Logos icons for packaged and running apps, keyboard shortcut handling, QML-only full-api UI doctest, and an arm linux CI build.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-basecamp/pull/294">#294</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/292">#292</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/290">#290</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/285">#285</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/283">#283</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/282">#282</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/281">#281</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/280">#280</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/276">#276</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/274">#274</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/272">#272</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/271">#271</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/270">#270</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-protocol">logos-protocol</a></h4>
+            <p>Multi-user groundwork: group-shareable local sockets with a stale-socket reaper and bind-failure detection, a transport-aware token validator hook on <code>ModuleProxy</code>, plus Qt thread-affinity fixes for client creation and destruction.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-protocol/pull/28">#28</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/27">#27</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/26">#26</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/24">#24</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/22">#22</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/20">#20</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-module-builder">logos-module-builder</a></h4>
+            <p>Protocol and Qt SDK re-pins carrying the multi-user socket and token validator work, design system bumps, and dependency forwarding to the standalone app.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-module-builder/pull/164">#164</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/163">#163</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/162">#162</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/160">#160</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/158">#158</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/156">#156</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/155">#155</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/154">#154</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/153">#153</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/152">#152</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-libp2p-module">logos-libp2p-module</a></h4>
+            <p>Runnable tutorial infrastructure with CI and docs generation, tutorials 2&ndash;11 authored, and hardened CI workflow permissions.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/91">#91</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/90">#90</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/89">#89</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/88">#88</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/87">#87</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/86">#86</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/85">#85</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/84">#84</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/81">#81</a>
+              <a href="https://github.com/logos-co/logos-libp2p-module/pull/80">#80</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-logoscore-cli">logos-logoscore-cli</a></h4>
+            <p>Operator-issued tokens enforced on <code>core_service</code> via a TokenStore-backed validator, <code>--access-group</code> to share the daemon with an OS group, stale socket reaping at daemon boot, and a multi-user systemd doctest.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/72">#72</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/71">#71</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/70">#70</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/66">#66</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/63">#63</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-qt-sdk">logos-qt-sdk</a></h4>
+            <p><code>LogosAPIProvider::setTokenValidator</code> forwards a token authorizer to <code>ModuleProxy</code>; rejection sentinel and replica-caching test alignment.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/17">#17</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/16">#16</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/15">#15</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/14">#14</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/11">#11</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-cpp-sdk">logos-cpp-sdk</a></h4>
+            <p><code>[bstr]</code> support for arrays of byte strings in cdylib, plus protocol bumps carrying the owner-thread and rejection re-exchange fixes.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/111">#111</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/110">#110</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/109">#109</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/108">#108</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/106">#106</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-chat-module">logos-chat-module</a></h4>
+            <p>Delivery node picks its own port; instance state stored under the host-assigned persistence path.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-chat-module/pull/54">#54</a>
+              <a href="https://github.com/logos-co/logos-chat-module/pull/53">#53</a>
+              <a href="https://github.com/logos-co/logos-chat-module/pull/52">#52</a>
+              <a href="https://github.com/logos-co/logos-chat-module/pull/51">#51</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-chat-ui">logos-chat-ui</a></h4>
+            <p>Chat storage taken from the host-assigned session directory, 1:1 flow renamed to "DM", and message text made selectable and copyable.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/43">#43</a>
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/42">#42</a>
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/41">#41</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-doctest">logos-doctest</a></h4>
+            <p><code>--workspace-pins</code> to build against a workspace snapshot, with nix override flag injection fixes.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-doctest/pull/9">#9</a>
+              <a href="https://github.com/logos-co/logos-doctest/pull/8">#8</a>
+              <a href="https://github.com/logos-co/logos-doctest/pull/7">#7</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-manager-ui">logos-package-manager-ui</a></h4>
+            <p>Static design system adoption, zero-repo state handling, and general enhancements.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-manager-ui/pull/60">#60</a>
+              <a href="https://github.com/logos-co/logos-package-manager-ui/pull/59">#59</a>
+              <a href="https://github.com/logos-co/logos-package-manager-ui/pull/55">#55</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-logoscore-py">logos-logoscore-py</a></h4>
+            <p>Transport e2e coverage for operator-issued token authorization; suite switched to the full-api test module across all types, events, and both codecs.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/10">#10</a>
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/9">#9</a>
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/8">#8</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-liblogos">logos-liblogos</a></h4>
+            <p>Protocol, Qt SDK, capability and module-loader-qt bumps carrying multi-user and token validator support.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-liblogos/pull/165">#165</a>
+              <a href="https://github.com/logos-co/logos-liblogos/pull/163">#163</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-view-module-runtime">logos-view-module-runtime</a></h4>
+            <p>Model pre-fetch added; QML bridge serializes <code>LogosResult</code> results instead of null.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-view-module-runtime/pull/18">#18</a>
+              <a href="https://github.com/logos-co/logos-view-module-runtime/pull/17">#17</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-wallet-ui">logos-wallet-ui</a></h4>
+            <p>Version 1.0.2 released; module-builder re-pinned to the ui-host token fix.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-wallet-ui/pull/19">#19</a>
+              <a href="https://github.com/logos-co/logos-wallet-ui/pull/18">#18</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-workspace">logos-workspace</a></h4>
+            <p>Nightly submodule bump; doctests built against the workspace snapshot in CI.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-workspace/pull/97">#97</a>
+              <a href="https://github.com/logos-co/logos-workspace/pull/96">#96</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-rust-sdk">logos-rust-sdk</a></h4>
+            <p>Module-builder bumps carrying logos-protocol #26 and #28.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/28">#28</a>
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/27">#27</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-downloader">logos-package-downloader</a></h4>
+            <p>Deleting and adding back the default repo now supported.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-downloader/pull/19">#19</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-module-loader-qt">logos-module-loader-qt</a></h4>
+            <p>Host quits cleanly on SIGTERM/SIGINT so the module's local socket is unlinked.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-module-loader-qt/pull/4">#4</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-doctest-hub">logos-doctest-hub</a></h4>
+            <p>Chat/delivery doctest suites added and tutorial lists refreshed.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-doctest-hub/pull/9">#9</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-capability-module">logos-capability-module</a></h4>
+            <p>Module-builder bump for the multi-user socket and token validator.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-capability-module/pull/21">#21</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-tutorial">logos-tutorial</a></h4>
+            <p>Launch timeout raised for the <code>nix run .</code> UI doctests.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-tutorial/pull/77">#77</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-storage-ui">logos-storage-ui</a></h4>
+            <p>Version bumped to 2.0.2 for release.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/70">#70</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-package-downloader-module">logos-package-downloader-module</a></h4>
+            <p>flake.lock bump.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-package-downloader-module/pull/18">#18</a>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <footer>
+        <p>Generated from weekly updates | Logos Collective Roadmap</p>
+      </footer>
+    </div>
+    <script>
+      // Tab switching
+      document.querySelectorAll(".tab").forEach((tab) => {
+        tab.addEventListener("click", () => {
+          const team = tab.dataset.team
+
+          document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"))
+          document.querySelectorAll(".team-content").forEach((c) => c.classList.remove("active"))
+
+          tab.classList.add("active")
+          document.getElementById(team).classList.add("active")
+        })
+      })
+
+      // Milestone toggle
+      function toggleMilestone(header) {
+        const milestone = header.closest(".milestone")
+        milestone.classList.toggle("expanded")
+      }
+
+      // Search functionality
+      const searchInput = document.getElementById("search")
+      searchInput.addEventListener("input", (e) => {
+        const searchTerm = e.target.value.toLowerCase()
+        const allContent = document.querySelectorAll(".milestone, .deliverable, .repo-card")
+
+        allContent.forEach((element) => {
+          const text = element.textContent.toLowerCase()
+          if (text.includes(searchTerm) || searchTerm === "") {
+            element.style.display = ""
+          } else {
+            element.style.display = "none"
+          }
+        })
+      })
+
+      // Keyboard navigation
+      document.addEventListener("keydown", (e) => {
+        if (e.ctrlKey || e.metaKey) {
+          const tabs = Array.from(document.querySelectorAll(".tab"))
+          const activeIndex = tabs.findIndex((t) => t.classList.contains("active"))
+
+          if (e.key === "ArrowLeft" && activeIndex > 0) {
+            e.preventDefault()
+            tabs[activeIndex - 1].click()
+          } else if (e.key === "ArrowRight" && activeIndex < tabs.length - 1) {
+            e.preventDefault()
+            tabs[activeIndex + 1].click()
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/content/reports/weekly/2026-08-03.html
+++ b/content/reports/weekly/2026-08-03.html
@@ -1,0 +1,1432 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logos Collective Weekly Summary - Week 31, 2026</title>
+    <style>
+      :root {
+        --bg-primary: #0d1117;
+        --bg-secondary: #161b22;
+        --bg-tertiary: #21262d;
+        --text-primary: #f0f6fc;
+        --text-secondary: #8b949e;
+        --border-color: #30363d;
+        --accent-storage: #3fb950;
+        --accent-messaging: #58a6ff;
+        --accent-logoscore: #a371f7;
+        --accent-blockchain: #f78166;
+        --accent-anoncomms: #d2a8ff;
+        --highlight-bg: rgba(56, 139, 253, 0.15);
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial,
+          sans-serif;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        line-height: 1.6;
+        min-height: 100vh;
+      }
+
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem;
+      }
+
+      header {
+        text-align: center;
+        margin-bottom: 3rem;
+        padding-bottom: 2rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      header h1 {
+        font-size: 2.5rem;
+        margin-bottom: 0.5rem;
+        background: linear-gradient(135deg, #58a6ff, #a371f7);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+
+      header .date {
+        color: var(--text-secondary);
+        font-size: 1.1rem;
+      }
+
+      .highlights-section {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        padding: 2rem;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .highlights-section h2 {
+        margin-bottom: 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .highlights-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+      }
+
+      .highlight-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        border-left: 4px solid;
+        transition:
+          transform 0.2s,
+          box-shadow 0.2s;
+      }
+
+      .highlight-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      .highlight-card.storage {
+        border-left-color: var(--accent-storage);
+      }
+      .highlight-card.messaging {
+        border-left-color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore {
+        border-left-color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain {
+        border-left-color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms {
+        border-left-color: var(--accent-anoncomms);
+      }
+
+      .highlight-card .team {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.5rem;
+        opacity: 0.8;
+      }
+
+      .highlight-card.storage .team {
+        color: var(--accent-storage);
+      }
+      .highlight-card.messaging .team {
+        color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore .team {
+        color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain .team {
+        color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms .team {
+        color: var(--accent-anoncomms);
+      }
+
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+      }
+
+      .tab {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: all 0.2s;
+        border: 1px solid var(--border-color);
+      }
+
+      .tab:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+      }
+
+      .tab.active {
+        color: var(--text-primary);
+      }
+
+      .tab.active.storage {
+        background: var(--accent-storage);
+        color: #000;
+      }
+      .tab.active.messaging {
+        background: var(--accent-messaging);
+        color: #000;
+      }
+      .tab.active.logoscore {
+        background: var(--accent-logoscore);
+        color: #000;
+      }
+      .tab.active.blockchain {
+        background: var(--accent-blockchain);
+        color: #000;
+      }
+      .tab.active.anoncomms {
+        background: var(--accent-anoncomms);
+        color: #000;
+      }
+
+      .team-content {
+        display: none;
+        animation: fadeIn 0.3s ease;
+      }
+
+      .team-content.active {
+        display: block;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      .milestone {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 1.5rem;
+        border: 1px solid var(--border-color);
+        overflow: hidden;
+      }
+
+      .milestone-header {
+        padding: 1rem 1.5rem;
+        background: var(--bg-tertiary);
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        user-select: none;
+      }
+
+      .milestone-header:hover {
+        background: rgba(48, 54, 61, 0.8);
+      }
+
+      .milestone-header h3 {
+        font-size: 1.1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .milestone-header h3 a {
+        color: var(--text-primary);
+        text-decoration: none;
+      }
+
+      .milestone-header h3 a:hover {
+        text-decoration: underline;
+      }
+
+      .milestone-toggle {
+        font-size: 1.5rem;
+        color: var(--text-secondary);
+        transition: transform 0.3s;
+      }
+
+      .milestone.expanded .milestone-toggle {
+        transform: rotate(180deg);
+      }
+
+      .milestone-body {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease;
+      }
+
+      .milestone.expanded .milestone-body {
+        max-height: 5000px;
+      }
+
+      .milestone-content {
+        padding: 1.5rem;
+      }
+
+      .deliverable {
+        margin-bottom: 1.5rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .deliverable:last-child {
+        margin-bottom: 0;
+        padding-bottom: 0;
+        border-bottom: none;
+      }
+
+      .deliverable h4 {
+        font-size: 1rem;
+        margin-bottom: 1rem;
+        color: var(--text-primary);
+      }
+
+      .deliverable h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .deliverable h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .section-label {
+        display: inline-block;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        margin-bottom: 0.5rem;
+      }
+
+      .section-label.achieved {
+        background: rgba(63, 185, 80, 0.2);
+        color: var(--accent-storage);
+      }
+
+      .section-label.next {
+        background: rgba(88, 166, 255, 0.2);
+        color: var(--accent-messaging);
+      }
+
+      .section-label.blockers {
+        background: rgba(247, 129, 102, 0.2);
+        color: var(--accent-blockchain);
+      }
+
+      .item-list {
+        list-style: none;
+        margin-left: 0;
+      }
+
+      .item-list li {
+        padding: 0.5rem 0;
+        padding-left: 1.5rem;
+        position: relative;
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+      }
+
+      .item-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.85rem;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--text-secondary);
+      }
+
+      .item-list li a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .item-list li a:hover {
+        text-decoration: underline;
+      }
+
+      .stats-bar {
+        display: flex;
+        gap: 2rem;
+        padding: 1rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+      }
+
+      .stat {
+        text-align: center;
+      }
+
+      .stat-value {
+        font-size: 2rem;
+        font-weight: 700;
+      }
+
+      .stat-label {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .repo-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 1rem;
+      }
+
+      .repo-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .repo-card h4 {
+        font-size: 0.95rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .repo-card h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .repo-card h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .repo-card p {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .pr-list {
+        margin-top: 0.5rem;
+      }
+
+      .pr-list a {
+        display: inline-block;
+        font-size: 0.8rem;
+        color: #58a6ff;
+        margin-right: 0.5rem;
+        text-decoration: none;
+      }
+
+      .pr-list a:hover {
+        text-decoration: underline;
+      }
+
+      .search-box {
+        margin-bottom: 1.5rem;
+      }
+
+      .search-box input {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+
+      .search-box input::placeholder {
+        color: var(--text-secondary);
+      }
+
+      .search-box input:focus {
+        outline: none;
+        border-color: #58a6ff;
+        box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.2);
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      footer {
+        text-align: center;
+        padding: 2rem;
+        color: var(--text-secondary);
+        border-top: 1px solid var(--border-color);
+        margin-top: 3rem;
+      }
+
+      @media (max-width: 768px) {
+        .container {
+          padding: 1rem;
+        }
+
+        header h1 {
+          font-size: 1.75rem;
+        }
+
+        .stats-bar {
+          justify-content: space-around;
+        }
+
+        .stat-value {
+          font-size: 1.5rem;
+        }
+      }
+      /* week-nav-css */
+      .week-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+        padding: 0.75rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .week-nav a {
+        color: var(--text-primary);
+        text-decoration: none;
+        padding: 0.5rem 1rem;
+        border-radius: 8px;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: background 0.2s;
+      }
+      .week-nav a:hover {
+        background: var(--bg-tertiary);
+      }
+      .week-nav .prev { margin-right: auto; }
+      .week-nav .next { margin-left: auto; }
+      .week-nav .spacer { flex: 1; }
+      /* /week-nav-css */
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Logos Collective Weekly Summary</h1>
+        <p class="date">Week 31, 2026 (August 3, 2026)</p>
+      </header>
+
+      <nav class="week-nav">
+        <a class="prev" data-router-ignore href="/reports/weekly/2026-07-27.html">&larr; 2026-07-27</a>
+        <a class="next" data-router-ignore href="/reports/weekly/2026-08-10.html">2026-08-10 &rarr;</a>
+      </nav>
+
+      <div class="stats-bar">
+        <div class="stat">
+          <div class="stat-value">4</div>
+          <div class="stat-label">Teams Reporting</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">160+</div>
+          <div class="stat-label">PRs &amp; Updates</div>
+        </div>
+      </div>
+
+      <section class="highlights-section">
+        <h2>Key Highlights</h2>
+        <div class="highlights-grid">
+          <div class="highlight-card messaging">
+            <div class="team">Messaging</div>
+            <p><strong>QUIC transport passed DST scale validation</strong>; RLN-sourced rate limiting and proof generation now enforced in the send service.</p>
+          </div>
+          <div class="highlight-card messaging">
+            <div class="team">Messaging</div>
+            <p><strong><code>logos-delivery-module</code> v0.2.0 released</strong> with Reliable Channels and Store query support; <code>logos-chat-module</code> and <code>logos-chat-ui</code> v0.2.1 released, the UI rebuilt on cards and avatars.</p>
+          </div>
+          <div class="highlight-card messaging">
+            <div class="team">Messaging</div>
+            <p><strong>SDS reliability live in Status Communities</strong> &mdash; message wrapping enabled, missed messages recovered via SDS, and "delivered" status driven by SDS acknowledgements.</p>
+          </div>
+          <div class="highlight-card blockchain">
+            <div class="team">Blockchain</div>
+            <p><strong>Logos Execution Zone v0.2.1 released</strong>; Node 0.2.1-rc.3 pre-release published; Anonymous Leaders Reward Protocol and gas metering merged in Nimbos.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p><strong>Zerokit v3.0.0 released</strong> and the deliverable closed, completing the enum-based runtime configuration refactor.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p>The service discovery protocol flaw found last week was <strong>fixed via spec and implementation changes</strong>; end-to-end shielded payment testing is working.</p>
+          </div>
+          <div class="highlight-card storage">
+            <div class="team">Storage</div>
+            <p><strong>Logos storage module v2.1.0 released</strong> with libstorage v0.4.2 and major NAT traversal improvements; Kad-DHT migration greenlit, retiring the discv5 fork.</p>
+          </div>
+        </div>
+      </section>
+
+      <div class="search-box">
+        <input
+          type="text"
+          id="search"
+          placeholder="Search updates (e.g., 'QUIC', 'RLN', 'NAT', 'Zerokit', 'sequencer')..."
+        />
+      </div>
+
+      <div class="tabs">
+        <button class="tab messaging active" data-team="messaging">Messaging</button>
+        <button class="tab blockchain" data-team="blockchain">Blockchain</button>
+        <button class="tab anoncomms" data-team="anoncomms">AnonComms</button>
+        <button class="tab storage" data-team="storage">Storage</button>
+      </div>
+
+      <!-- ================================================================
+             MESSAGING
+             ================================================================ -->
+      <div class="team-content active" id="messaging">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Messaging API &mdash; General Availability</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/429">Reliability and scale validation with DST</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Add <code>logosdeliverynode</code> docker-compose stack &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4057">#4057</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Test suite for Messaging API</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>CI issue fixed (reports / flaky tests) &mdash; <a href="https://github.com/logos-messaging/logos-delivery-interop-tests/pull/202">logos-delivery-interop-tests#202</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Port remaining wrapper tests from the interop repo &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4077">#4077</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/431">Create Rate Limit Manager</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Per-epoch rate limit enforced at the send service</strong> (RLN-sourced) &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4062">#4062</a></li>
+                  <li>RLN proofs attached and refreshed in the send service (Stream B) &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4069">#4069</a></li>
+                  <li>Rate-limit epoch period and send-service cache TTL inconsistency identified &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4049">#4049</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Implement a configurable approached state for rate-limit-manager &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4090">#4090</a></li>
+                  <li>Do not schedule ephemeral messages if the rate limit is approached &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4091">#4091</a></li>
+                  <li>Add cap for parked tasks in the send scheduler &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4092">#4092</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/432">Integrate Rate Limit Manager</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Rate-limit-manager must use the remaining budget provided by the RLN API module to drive send scheduling &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4089">#4089</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Reliable Channel API &mdash; Beta</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Reliable Channel API stabilization and bug fixes</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Stopped emitting receive events after <code>channel_close</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4075">#4075</a></li>
+                  <li>Subscribe to the channel's content topic on <code>channel_create</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4081">#4081</a></li>
+                  <li>SIGSEGV during node shutdown after restoring persisted reliable-channel state &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4103">#4103</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Messaging API and Reliable Channel API share kernel state without ownership &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4087">#4087</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Support QUIC Transport in Logos Delivery</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/324">Trial QUIC</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>DST scale validation of QUIC transport completed</strong> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/3986">#3986</a></li>
+                  <li>Host OpenSSL stopped from hijacking bundled BoringSSL in <code>liblogosdelivery</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4086">#4086</a></li>
+                  <li>QUIC defaulted off on the messaging path &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4084">#4084</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Bump <code>nim-lsquic</code> v0.5.1 &rarr; v0.5.6 &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4055">#4055</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>RLN on Logos Blockchain</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/416">Implement pluggable RLN membership interface</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>RLN interface API defined &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4016">#4016</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Rewire the RLN implementation to use the RLN API module &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4088">#4088</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Fleet Stability</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/382">Fleet monitoring dashboards for Logos fleets</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Fleet dashboards synced from Grafana &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4079">#4079</a></li>
+                  <li>Prometheus and Grafana connected to the logos.dev fleet &mdash; <a href="https://github.com/status-im/infra-logos/issues/27">infra-logos#27</a></li>
+                  <li>logos.dev fleet delivery nodes added to Kuma Canaries &mdash; <a href="https://github.com/status-im/infra-logos/issues/19">infra-logos#19</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Missing data in some Grafana dashboards &mdash; <a href="https://github.com/logos-messaging/logos-delivery/issues/4078">#4078</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/384">Resolve known fleet stability issues</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>nim-libp2p v2.2.0 migration and NAT overhaul</strong>: <a href="https://github.com/logos-messaging/logos-delivery/pull/4093">deps bump</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4094">adapt Logos Delivery</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4095">resolve dynamic ports in announced addresses</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4096">typed NAT policy boundary</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4097">adopt libp2p NATService</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4098">announce NAT-mapped external addresses</a>, <a href="https://github.com/logos-messaging/logos-delivery/pull/4099">harden NAT mapping and discv5 projection</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Migrate to nim-libp2p v2.2.0 &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4102">#4102</a></li>
+                  <li>Partition <code>messages_lookup</code> so retention drops partitions instead of mass-deleting rows <a href="https://github.com/logos-messaging/logos-delivery/pull/4106">#4106</a> (fixes the <a href="https://github.com/logos-messaging/logos-delivery/issues/4105">broken AMS logos.test store</a>)</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Chat &mdash; Beta</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/439">Implement full identity model</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Keypackage Caching server updated to accept publications over &lambda;Delivery &mdash; <a href="https://github.com/logos-messaging/chat-store/pull/7">chat-store#7</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/440">Stabilize and polish API</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>(New Contributor) ChatCLI build fixed &mdash; <a href="https://github.com/logos-messaging/libchat/pull/197">libchat#197</a></li>
+                  <li>Bug hunting &mdash; <a href="https://github.com/logos-messaging/libchat/issues/199">libchat#199</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Core Integration &mdash; Phase 2 &amp; 3</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/388">Add Reliable Channel API to Logos Core Delivery module</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong><a href="https://github.com/logos-co/logos-delivery-module/releases/tag/v0.2.0"><code>logos-delivery-module</code> v0.2.0 released</a></strong> with Reliable Channels API and Store queries</li>
+                  <li><code>localStoragePath</code> added to <code>MessagingClientConf</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4083">#4083</a></li>
+                  <li>Three <code>createNode</code> config shapes documented &mdash; <a href="https://github.com/logos-co/logos-delivery-module/pull/79">logos-delivery-module#79</a></li>
+                  <li><code>version()</code> API method dropped &mdash; <a href="https://github.com/logos-co/logos-delivery-module/pull/80">logos-delivery-module#80</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Logos Chat module and UI for Logos Core</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong><a href="https://github.com/logos-co/logos-chat-module/releases/tag/v0.2.1"><code>logos-chat-module</code> v0.2.1 released</a></strong> &mdash; <code>init</code> reshaped around a <code>ChatConfig</code> record, instance storage under the host-assigned persistence path, delivery node picks its own port, conversation roster reports pending invites, log level/<code>get_log_path</code>/lock-free <code>health()</code></li>
+                  <li><a href="https://github.com/logos-co/logos-chat-module/releases/tag/v0.2.2"><code>logos-chat-module</code> v0.2.2</a> and <a href="https://github.com/logos-co/logos-chat-ui/releases/tag/v0.2.2"><code>logos-chat-ui</code> v0.2.2</a> released against <code>delivery_module</code> v0.2.0 (layered <code>createNode</code> config)</li>
+                  <li>Chat UI rebuilt on cards, avatars and one action per surface &mdash; <a href="https://github.com/logos-co/logos-chat-ui/pull/48">logos-chat-ui#48</a></li>
+                  <li>Run failures held with the logs that explain them &mdash; <a href="https://github.com/logos-co/logos-chat-ui/pull/50">logos-chat-ui#50</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/449">Make discovery pluggable in Logos Delivery</a></h4>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Support discovery plugins in <code>logos-delivery</code></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Introduce E2E Reliability in Status Communities</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/304">SDS protocol in Status &mdash; basic recovery</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Missing envelopes fetched when an SDS signal arrives &mdash; <a href="https://github.com/status-im/status-go/issues/7363">status-go#7363</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-messaging/pm/issues/385">SDS protocol in Status &mdash; enable wrapping for communities messages</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>SDS wrap process enabled for sending community messages</strong> &mdash; <a href="https://github.com/status-im/status-go/issues/7151">status-go#7151</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Maintenance</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Logos Delivery</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><code>nim-ffi</code> bumped to 0.3.0-rc.1 (per-listener event ABI) &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4070">#4070</a></li>
+                  <li><code>MaxMessageSize</code> node info item exposed &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4018">#4018</a></li>
+                  <li>Logging policy added &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4104">#4104</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Migrate <code>liblogosdelivery</code> to the nim-ffi 0.3.0 typed C ABI &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4082">#4082</a></li>
+                  <li>Replace <code>minprotobuf</code> with <code>nim-protobuf-serialization</code> &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4046">#4046</a></li>
+                  <li>Pull and publish the Logos Attic cache in nix builds &mdash; <a href="https://github.com/logos-messaging/logos-delivery/pull/4071">#4071</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             BLOCKCHAIN
+             ================================================================ -->
+      <div class="team-content" id="blockchain">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Bedrock &mdash; Research</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Cryptarchia</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Fast Bootstrapping implementation prep: channel state <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3194">#3194</a>, SDP declarations <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3208">#3208</a>, locked notes <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3214">#3214</a>, and voucher nullifiers <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3215">#3215</a> migrated to fixed blake2b merkle-tree structures</li>
+                  <li>Compressed Block Proposal RFC approved <a href="https://app.notion.com/p/nomos-tech/RFC-Compressed-Block-Proposal-2e3261aa09df80a38df7eb9f14ddeb5e">doc</a>; LIP opened (in-review) <a href="https://github.com/logos-co/logos-lips/pull/389">logos-lips#389</a></li>
+                  <li>Spec emergency fixes merged: <code>CHANNEL_DEPOSIT</code> execution and block limit <a href="https://github.com/logos-co/logos-lips/pull/381">logos-lips#381</a>, with implementation <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3189">#3189</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Post-Quantum</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Post-Quantum primitive benchmark document restructured with Rust results and cross-platform graphs <a href="https://app.notion.com/p/nomos-tech/Post-Quantum-Primitive-Benchmarks-390261aa09df80ad826ed884620222ce">doc</a>; dashboard extended to 4 platforms <a href="https://megonen.github.io/pqc-bench/">dashboard</a></li>
+                  <li>Post-Quantum Primitive Candidates for the Bedrock layer updated for consistency with the Blend and Bedrock safety analyses &mdash; <a href="https://app.notion.com/p/nomos-tech/Post-Quantum-Primitive-Candidates-for-the-Logos-Bedrock-Layer-376261aa09df80348969f89b1f3ed8e9">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Total Stake Inference</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>"Modelling of Network Delays" <a href="https://app.notion.com/p/nomos-tech/Modelling-of-Network-Delays-357261aa09df806ab687c115e5ba55e0">doc</a> and "Total Stake Inference with Network Delays" <a href="https://app.notion.com/p/nomos-tech/Total-Stake-Inference-with-Network-Delays-372261aa09df82188afd01720e33a79c">doc</a> finalized and approved</strong></li>
+                  <li>Cryptarchia with uncle references RFC opened (in-review) <a href="https://github.com/logos-co/logos-lips/pull/385">logos-lips#385</a>, backed by per-node Total Stake Inference simulations <a href="https://github.com/logos-blockchain/research/tree/master/tools/simulators/tsi/tsi-sim-pernode">code</a> and gathered results <a href="https://github.com/logos-blockchain/research/tree/master/reports/tsi">report</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>EmPoWering</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Acceleration-resistant Proof of Work survey completed <a href="https://github.com/logos-blockchain/research/blob/master/reports/EmPoWering/Acceleration-Resistant-PoW-Survey.md">report</a>; Equi-X benchmarking tool built <a href="https://github.com/logos-blockchain/research/tree/master/tools/benchmarks/Equi-X">code</a> with analysis <a href="https://github.com/logos-blockchain/research/tree/master/reports/EmPoWering/Equi-X">report</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Cross-Zone Sequencing</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Costly Abort Mechanism Direction 1 completed: <code>proposal_id</code> commitments provably tied to valid intents via a two-layer construction, audited end to end for self-consistency and optimism &mdash; <a href="https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-396261aa09df80f99b7ffcd6ed76e0aa">doc</a></li>
+                  <li>Costly Abort Mechanism formal specification written &mdash; <a href="https://app.notion.com/p/nomos-tech/Costly-Abort-Mechanism-Specification-3ab261aa09df80c88844f4edd21e19de">doc</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Anonymous Communications</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Single-path mix latency law replaced with a shifted log-normal moment-matched to real inter-city pings, and a first mix-net grid layer built with a route-marginalising Bayesian attack &mdash; <a href="https://app.notion.com/p/nomos-tech/Lognormal-single-path-mix-model-and-mixnet-c7c261aa09df82ada05681411003be88">doc</a></li>
+                  <li>Log-normal single-path mix model and Dandelion++ comparison write-up (WIP) &mdash; <a href="https://nomos-tech.notion.site/Log-normal-Single-Path-Mix-Model-and-Dandelion-3b0261aa09df80678d59d03af2dd27b7">doc</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Bedrock &mdash; Engineering</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Security Audit</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Unified <code>BinaryEncode</code>/<code>BinaryDecode</code> trait system with fixture testing merged</strong>, replacing the legacy wire encoding &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3198">#3198</a>, <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3201">#3201</a></li>
+                  <li>Bounded-input hardening merged: bounded and validated merkle paths <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3183">#3183</a>, bounded vecs replaced with fixed-size arrays <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3191">#3191</a>, deposit inputs bounded <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3199">#3199</a>, decode mitigations for bounded vectors <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3224">#3224</a></li>
+                  <li>Remaining boundedness hardening (in-review): high-value candidates <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3225">#3225</a>, serde JSON <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3228">#3228</a>, alternate wire deserialisation paths <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3230">#3230</a></li>
+                  <li>Dead/unused code cleanup (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3227">#3227</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Blend</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Message encapsulation aligned with the spec: missing headers padded and payload padding randomised &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3217">#3217</a></li>
+                  <li>Proof of Quota verification benchmarks added &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3197">#3197</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Node</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Operation typestate groundwork toward <code>SignedOp</code>: Op preverification unified <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3200">#3200</a>; <code>VerificationMode</code> marker and Operation trait split (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3234">#3234</a>; <code>ProvableOperation</code> trait (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3235">#3235</a></li>
+                  <li>Execution market: fee prices rounded up so they can rise from low values <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3190">#3190</a> with the spec ceiling-formula fix <a href="https://github.com/logos-co/logos-lips/pull/384">logos-lips#384</a>; constants aligned with spec <code>G_max</code>/<code>G_target</code> <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3187">#3187</a></li>
+                  <li>SDP declaration ID computation fixed with length-prefixed locators <a href="https://github.com/logos-co/logos-lips/pull/386">logos-lips#386</a>, <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3218">#3218</a></li>
+                  <li>Pending mempool transactions evicted after a configurable TTL (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3210">#3210</a>; typed 404 responses for missing channels (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3229">#3229</a></li>
+                  <li>Mantle gas-cost APIs clarified as predictions, with per-operation minimum proof counts to avoid <code>InsufficientGas</code> errors &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3186">#3186</a></li>
+                  <li>Cryptarchia walk-back functions hardened against potential infinite loops and panics (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3209">#3209</a></li>
+                  <li>Overwatch returns errors instead of panicking after shutdown <a href="https://github.com/logos-co/Overwatch/pull/146">Overwatch#146</a>; Rust toolchain updated to 1.97.1 <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3207">#3207</a>, <a href="https://github.com/logos-co/Overwatch/pull/147">Overwatch#147</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Testing</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Fee-market end-to-end tests merged: price rise/recovery scenarios <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3111">#3111</a> and tip-headroom coverage for gas price updates <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3223">#3223</a></li>
+                  <li>Wallet-drain ability added to the cucumber suite <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3188">#3188</a>; dead test code removed <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3205">#3205</a></li>
+                  <li>Merge-queue CI hardened: workflow final steps fixed <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3193">#3193</a>, fail-fast integration tests <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3203">#3203</a>, merge-queue integration-test improvements <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3206">#3206</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Zone SDK</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Funding priority fee made configurable &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3195">#3195</a></li>
+                  <li>C bindings implement the full <code>Node</code> interface merged <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3173">#3173</a>, with a default <code>Node</code> trait adapter <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3213">#3213</a>, groundwork for a switchable API backend</li>
+                  <li>Backfilling fixes merged: gap-backfilled inscriptions surface as adopted, orphaned finalized transactions handled &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3079">#3079</a></li>
+                  <li>Indexer removal in favor of the sequencer for reads and writes (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3220">#3220</a>; pending inscriptions invalidated on config update (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3237">#3237</a></li>
+                  <li>Zone SDK client packaging decided: <code>blockchain-module</code> becomes a mono-repo vendoring generated <code>logos-rust-sdk</code> code, so cargo builds no longer require nix</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Logos Core Integration</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Node 0.2.1-rc.3 pre-release published</strong> <a href="https://github.com/logos-blockchain/logos-blockchain/issues/3212">#3212</a>, with the blockchain module updated to match</li>
+                  <li>Backoff strategy for dashboard status polling merged &mdash; <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/45">logos-blockchain-ui#45</a></li>
+                  <li>FFI config environment-variable overrides fixed (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3219">#3219</a>; versioned Tools image built during releases (in-review) <a href="https://github.com/logos-blockchain/logos-blockchain/pull/3221">#3221</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Logos Execution Zone (LEZ)</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Release</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Logos Execution Zone v0.2.1 released</strong> <a href="https://github.com/logos-blockchain/logos-execution-zone/releases/tag/v0.2.1">release</a>: Bedrock node and Zone SDK bumped <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/654">#654</a>, dev merged to main <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/661">#661</a>, <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/663">#663</a>, nix packaging and artifacts-builder fixes <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/658">#658</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Sequencer</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Multi-sequencer client parallelism merged &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/638">#638</a></li>
+                  <li><strong>Sequencer self-join/leave mechanism design finished</strong> <a href="https://app.notion.com/p/Sequencer-self-join-specs-3ab8f96fb65c80a4b642d415b4a8f26b">doc</a>; implementation opened (WIP, draft) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/653">#653</a></li>
+                  <li>Sequencer communication mechanism research concluded: <strong>libp2p chosen</strong> <a href="https://app.notion.com/p/Analyze-and-decide-the-sequencer-communication-mechanism-3aa8f96fb65c80258b92c331bb579d55">doc</a>; gossip module opened (WIP, draft) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/662">#662</a></li>
+                  <li>Channel config transactions funded via the node wallet &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/659">#659</a></li>
+                  <li>Sequencer metrics and a Grafana dashboard generation tool (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/651">#651</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Cross-Zone</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Generalization Phase 0 landed: forgery test gated on a verified peer-chain prefix <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/649">#649</a>, watcher peer read cursors persisted <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/652">#652</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Accounts</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Dummy-note padding merged <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/592">#592</a>; note and cipher order obfuscation merged <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/564">#564</a></li>
+                  <li>Private/public i/o bundled into action structs (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/604">#604</a></li>
+                  <li>Environment unification: public-private semantic discrepancies documented <a href="https://hackmd.io/@tgReoUp4TR6_bM3e22EdBQ/B1791IIBMl">doc</a>, proof-of-concept opened (WIP, draft) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/650">#650</a>, private-kinds refactor opened as part 1 of the unification PR stack (in-review) <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/660">#660</a></li>
+                  <li>Incremental account updates explored (WIP, draft) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/656">#656</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Proofs</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Groth16 proving evaluated in the Logos Execution Zone: memory requirement identified as the limiting factor (draft) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/645">#645</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Wallet UI</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Public-account initialize button merged <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/28">logos-execution-zone-wallet-ui#28</a>; account labels merged <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/29">#29</a></li>
+                  <li><code>lez_core</code> module updated to latest dev with new statistics FFI arguments (in-review) &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone-module/pull/43">logos-execution-zone-module#43</a></li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4>Refactor</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Valid-proof test removed from per-PR CI runs &mdash; <a href="https://github.com/logos-blockchain/logos-execution-zone/pull/646">#646</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Nimbos</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Nimbos</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Anonymous Leaders Reward Protocol ledger state and claim path merged</strong> &mdash; <a href="https://github.com/logos-co/nimbos/pull/134">nimbos#134</a></li>
+                  <li><strong>Gas metering merged</strong> &mdash; <a href="https://github.com/logos-co/nimbos/pull/149">nimbos#149</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             ANONCOMMS
+             ================================================================ -->
+      <div class="team-content" id="anoncomms">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Create a basic service discovery module</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/36">Validate service discovery protocol correctness in large-scale simulations</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Protocol improvement PRs opened</li>
+                  <li><strong>The protocol flaw discovered last week was fixed</strong> via spec and implementation changes</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Validate the improvements via a test scenario</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Establish libp2p mixnet</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/51">Research more advanced cover traffic generation techniques</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Review comments addressed on the <a href="https://github.com/logos-co/logos-lips/pull/341">cover traffic spec update</a></li>
+                  <li>Mix code analyzed for issues and gaps, and addressed: <a href="https://github.com/logos-co/nim-libp2p-mix/pull/36">expire SURB credentials</a>, <a href="https://github.com/logos-co/nim-libp2p-mix/pull/40">claim cover slot for SURB reply</a>, <a href="https://github.com/logos-co/nim-libp2p-mix/pull/41">remove unused fragmentation logic</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Start analyzing other cover traffic strategies</li>
+                  <li>Continue mix code improvements</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/52">Implement local reputation mechanism and research advanced DoS protection</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Comparison document of RLN-based DoS protection schemes for Mix shared for review</li>
+                  <li>Identified an issue where the <a href="https://github.com/logos-co/mix-rln-spam-protection-plugin/issues/14">clock-skew window allows 11x the configured rate limit</a>; fix opened in <a href="https://github.com/logos-co/mix-rln-spam-protection-plugin/pull/13">PR #13</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Address feedback on the DoS schemes comparison document and decide whether to implement</li>
+                  <li>Research a local reputation mechanism (Blend/Loopix-style)</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Deliver de-MLS for p2p group messaging</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/62">Implementing recovery mode</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Bug fixed with non-determinism in steward reelection</li>
+                  <li>Create-with-members feature moved into a separate PR and implemented on the libchat side</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Continue working on the recovery mechanism</li>
+                  <li>Try the option-timer idea</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/63">Integrating de-MLS into libchat</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Implemented a request to return the signer together with a message</li>
+                  <li>Started a discussion about member-id representation</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Resolve and merge the member-id representation</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Implement RLN membership allocation service</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/83">Full RLN module</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>RLN Logos Core module expanded to handle proof generation, proof verification, and managing rate limits per membership</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Decentralised Oracle Network</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/56">Specifying oracle mechanism</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><a href="https://github.com/logos-co/logos-lips/pull/388">Spec PR</a> opened specifying the proposer selection mechanism</li>
+                  <li>Implementation work: sequencer and indexer code, plus blockchain time info</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Address review feedback and formalize all the LEZ contracts</li>
+                  <li>Review the RFC for the indexer proposer; continue implementation work</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Implement an MVP payment protocol</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/73">Specify and implement client payment shielding via LEZ private execution mode</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>End-to-end shielded testing is working</strong></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Spec updates</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Maintain and expand Zerokit</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/60">Release Zerokit (v3.0.0) with enum-based runtime configuration (CLOSED)</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Final PRs reviewed and merged: <a href="https://github.com/vacp2p/zerokit/pull/430">#430</a> into the develop PR, followed by merging the <a href="https://github.com/vacp2p/zerokit/pull/428">develop PR</a> into master</li>
+                  <li><strong><code>v3.0.0</code> release tag created and the <a href="https://github.com/logos-co/anoncomms-pm/issues/60">deliverable</a> closed</strong></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Publish the new versions of <code>rln</code> and <code>zerokit_utils</code> to crates.io and the new <code>rln-wasm</code> packages to npm</li>
+                  <li>Consider the next developments</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             STORAGE
+             ================================================================ -->
+      <div class="team-content" id="storage">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Releases</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Logos storage module v2.1.0</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong><a href="https://github.com/logos-co/logos-storage-module/releases/tag/v2.1.0">v2.1.0 of the Logos storage module is out</a></strong>, bringing libstorage v0.4.2 with major improvements to NAT traversal as well as other bugfixes and improvements &mdash; <a href="https://github.com/logos-storage/logos-storage-nim/releases/tag/v0.4.2">release notes</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/20">Hidden Services Over Mix</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Mix path selection</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Studied and experimented with mix path selection from related papers (<a href="https://dl.acm.org/doi/pdf/10.1145/3564625.3567996">1</a>, <a href="https://www.ndss-symposium.org/wp-content/uploads/2026-f2384-paper.pdf">2</a>) to address the malicious path problem in both anonymous download and hidden services &mdash; work-in-progress <a href="https://hackmd.io/@codex-storage/rJ4d1aaHfe">summary/notes</a> and <a href="https://github.com/logos-storage/hs-mix-sim">experiment code</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Continue experimentation and document the results</li>
+                  <li>Based on results, write specs for mix path selection to be used for anonymous download over the transport layer, and later on for hidden services</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/3">Anonymous DHT Queries</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>Kad-DHT evaluation</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>libp2p Kademlia DHT evaluated</strong> &mdash; initial evaluation shows no blockers, and the migration has been greenlit; the discv5 fork will soon be retired</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Replace the discv5 DHT with the libp2p Kademlia DHT</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3><a href="https://github.com/logos-storage/logos-storage-pm/issues/24">Storage Documentation</a></h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4>API docs generation workflows</h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Two workflows in progress &mdash; at the source repo: on push to master, generate a JSON payload of the API docs from the source C/C++ headers (and where they should live in the target) and push a repository dispatch event to the docs repo; on release, create a release in the docs repo with the generated API docs</li>
+                  <li>At the docs repo (target): generate API docs from the source specified in the JSON payload, and create a PR with the generated API docs</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Finish the two workflows for generating API docs and the spec documenting it</li>
+                  <li>Add support for config documentation generation in the workflows</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <footer>
+        <p>Generated from weekly updates | Logos Collective Roadmap</p>
+      </footer>
+    </div>
+    <script>
+      // Tab switching
+      document.querySelectorAll(".tab").forEach((tab) => {
+        tab.addEventListener("click", () => {
+          const team = tab.dataset.team
+
+          document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"))
+          document.querySelectorAll(".team-content").forEach((c) => c.classList.remove("active"))
+
+          tab.classList.add("active")
+          document.getElementById(team).classList.add("active")
+        })
+      })
+
+      // Milestone toggle
+      function toggleMilestone(header) {
+        const milestone = header.closest(".milestone")
+        milestone.classList.toggle("expanded")
+      }
+
+      // Search functionality
+      const searchInput = document.getElementById("search")
+      searchInput.addEventListener("input", (e) => {
+        const searchTerm = e.target.value.toLowerCase()
+        const allContent = document.querySelectorAll(".milestone, .deliverable, .repo-card")
+
+        allContent.forEach((element) => {
+          const text = element.textContent.toLowerCase()
+          if (text.includes(searchTerm) || searchTerm === "") {
+            element.style.display = ""
+          } else {
+            element.style.display = "none"
+          }
+        })
+      })
+
+      // Keyboard navigation
+      document.addEventListener("keydown", (e) => {
+        if (e.ctrlKey || e.metaKey) {
+          const tabs = Array.from(document.querySelectorAll(".tab"))
+          const activeIndex = tabs.findIndex((t) => t.classList.contains("active"))
+
+          if (e.key === "ArrowLeft" && activeIndex > 0) {
+            e.preventDefault()
+            tabs[activeIndex - 1].click()
+          } else if (e.key === "ArrowRight" && activeIndex < tabs.length - 1) {
+            e.preventDefault()
+            tabs[activeIndex + 1].click()
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/content/reports/weekly/2026-08-10.html
+++ b/content/reports/weekly/2026-08-10.html
@@ -1,0 +1,1164 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Logos Collective Weekly Summary - Week 32, 2026</title>
+    <style>
+      :root {
+        --bg-primary: #0d1117;
+        --bg-secondary: #161b22;
+        --bg-tertiary: #21262d;
+        --text-primary: #f0f6fc;
+        --text-secondary: #8b949e;
+        --border-color: #30363d;
+        --accent-storage: #3fb950;
+        --accent-messaging: #58a6ff;
+        --accent-logoscore: #a371f7;
+        --accent-blockchain: #f78166;
+        --accent-anoncomms: #d2a8ff;
+        --highlight-bg: rgba(56, 139, 253, 0.15);
+      }
+
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial,
+          sans-serif;
+        background: var(--bg-primary);
+        color: var(--text-primary);
+        line-height: 1.6;
+        min-height: 100vh;
+      }
+
+      .container {
+        max-width: 1400px;
+        margin: 0 auto;
+        padding: 2rem;
+      }
+
+      header {
+        text-align: center;
+        margin-bottom: 3rem;
+        padding-bottom: 2rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      header h1 {
+        font-size: 2.5rem;
+        margin-bottom: 0.5rem;
+        background: linear-gradient(135deg, #58a6ff, #a371f7);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+      }
+
+      header .date {
+        color: var(--text-secondary);
+        font-size: 1.1rem;
+      }
+
+      .highlights-section {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        padding: 2rem;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .highlights-section h2 {
+        margin-bottom: 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .highlights-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+      }
+
+      .highlight-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem 1.25rem;
+        border-left: 4px solid;
+        transition:
+          transform 0.2s,
+          box-shadow 0.2s;
+      }
+
+      .highlight-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      .highlight-card.storage {
+        border-left-color: var(--accent-storage);
+      }
+      .highlight-card.messaging {
+        border-left-color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore {
+        border-left-color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain {
+        border-left-color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms {
+        border-left-color: var(--accent-anoncomms);
+      }
+
+      .highlight-card .team {
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.5rem;
+        opacity: 0.8;
+      }
+
+      .highlight-card.storage .team {
+        color: var(--accent-storage);
+      }
+      .highlight-card.messaging .team {
+        color: var(--accent-messaging);
+      }
+      .highlight-card.logoscore .team {
+        color: var(--accent-logoscore);
+      }
+      .highlight-card.blockchain .team {
+        color: var(--accent-blockchain);
+      }
+      .highlight-card.anoncomms .team {
+        color: var(--accent-anoncomms);
+      }
+
+      .tabs {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1.5rem;
+        flex-wrap: wrap;
+      }
+
+      .tab {
+        padding: 0.75rem 1.5rem;
+        border: none;
+        background: var(--bg-secondary);
+        color: var(--text-secondary);
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: all 0.2s;
+        border: 1px solid var(--border-color);
+      }
+
+      .tab:hover {
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+      }
+
+      .tab.active {
+        color: var(--text-primary);
+      }
+
+      .tab.active.storage {
+        background: var(--accent-storage);
+        color: #000;
+      }
+      .tab.active.messaging {
+        background: var(--accent-messaging);
+        color: #000;
+      }
+      .tab.active.logoscore {
+        background: var(--accent-logoscore);
+        color: #000;
+      }
+      .tab.active.blockchain {
+        background: var(--accent-blockchain);
+        color: #000;
+      }
+      .tab.active.anoncomms {
+        background: var(--accent-anoncomms);
+        color: #000;
+      }
+
+      .team-content {
+        display: none;
+        animation: fadeIn 0.3s ease;
+      }
+
+      .team-content.active {
+        display: block;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(10px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+      .milestone {
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 1.5rem;
+        border: 1px solid var(--border-color);
+        overflow: hidden;
+      }
+
+      .milestone-header {
+        padding: 1rem 1.5rem;
+        background: var(--bg-tertiary);
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        user-select: none;
+      }
+
+      .milestone-header:hover {
+        background: rgba(48, 54, 61, 0.8);
+      }
+
+      .milestone-header h3 {
+        font-size: 1.1rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .milestone-header h3 a {
+        color: var(--text-primary);
+        text-decoration: none;
+      }
+
+      .milestone-header h3 a:hover {
+        text-decoration: underline;
+      }
+
+      .milestone-toggle {
+        font-size: 1.5rem;
+        color: var(--text-secondary);
+        transition: transform 0.3s;
+      }
+
+      .milestone.expanded .milestone-toggle {
+        transform: rotate(180deg);
+      }
+
+      .milestone-body {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease;
+      }
+
+      .milestone.expanded .milestone-body {
+        max-height: 5000px;
+      }
+
+      .milestone-content {
+        padding: 1.5rem;
+      }
+
+      .deliverable {
+        margin-bottom: 1.5rem;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--border-color);
+      }
+
+      .deliverable:last-child {
+        margin-bottom: 0;
+        padding-bottom: 0;
+        border-bottom: none;
+      }
+
+      .deliverable h4 {
+        font-size: 1rem;
+        margin-bottom: 1rem;
+        color: var(--text-primary);
+      }
+
+      .deliverable h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .deliverable h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .section-label {
+        display: inline-block;
+        padding: 0.25rem 0.5rem;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        margin-bottom: 0.5rem;
+      }
+
+      .section-label.achieved {
+        background: rgba(63, 185, 80, 0.2);
+        color: var(--accent-storage);
+      }
+
+      .section-label.next {
+        background: rgba(88, 166, 255, 0.2);
+        color: var(--accent-messaging);
+      }
+
+      .section-label.blockers {
+        background: rgba(247, 129, 102, 0.2);
+        color: var(--accent-blockchain);
+      }
+
+      .item-list {
+        list-style: none;
+        margin-left: 0;
+      }
+
+      .item-list li {
+        padding: 0.5rem 0;
+        padding-left: 1.5rem;
+        position: relative;
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+      }
+
+      .item-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.85rem;
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: var(--text-secondary);
+      }
+
+      .item-list li a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .item-list li a:hover {
+        text-decoration: underline;
+      }
+
+      .stats-bar {
+        display: flex;
+        gap: 2rem;
+        padding: 1rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        margin-bottom: 2rem;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+      }
+
+      .stat {
+        text-align: center;
+      }
+
+      .stat-value {
+        font-size: 2rem;
+        font-weight: 700;
+      }
+
+      .stat-label {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .repo-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+        gap: 1rem;
+      }
+
+      .repo-card {
+        background: var(--bg-tertiary);
+        border-radius: 8px;
+        padding: 1rem;
+        border: 1px solid var(--border-color);
+      }
+
+      .repo-card h4 {
+        font-size: 0.95rem;
+        margin-bottom: 0.75rem;
+      }
+
+      .repo-card h4 a {
+        color: #58a6ff;
+        text-decoration: none;
+      }
+
+      .repo-card h4 a:hover {
+        text-decoration: underline;
+      }
+
+      .repo-card p {
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+      }
+
+      .pr-list {
+        margin-top: 0.5rem;
+      }
+
+      .pr-list a {
+        display: inline-block;
+        font-size: 0.8rem;
+        color: #58a6ff;
+        margin-right: 0.5rem;
+        text-decoration: none;
+      }
+
+      .pr-list a:hover {
+        text-decoration: underline;
+      }
+
+      .search-box {
+        margin-bottom: 1.5rem;
+      }
+
+      .search-box input {
+        width: 100%;
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        background: var(--bg-secondary);
+        color: var(--text-primary);
+        font-size: 1rem;
+      }
+
+      .search-box input::placeholder {
+        color: var(--text-secondary);
+      }
+
+      .search-box input:focus {
+        outline: none;
+        border-color: #58a6ff;
+        box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.2);
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      footer {
+        text-align: center;
+        padding: 2rem;
+        color: var(--text-secondary);
+        border-top: 1px solid var(--border-color);
+        margin-top: 3rem;
+      }
+
+      @media (max-width: 768px) {
+        .container {
+          padding: 1rem;
+        }
+
+        header h1 {
+          font-size: 1.75rem;
+        }
+
+        .stats-bar {
+          justify-content: space-around;
+        }
+
+        .stat-value {
+          font-size: 1.5rem;
+        }
+      }
+      /* week-nav-css */
+      .week-nav {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1.5rem;
+        padding: 0.75rem 1.5rem;
+        background: var(--bg-secondary);
+        border-radius: 12px;
+        border: 1px solid var(--border-color);
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+      .week-nav a {
+        color: var(--text-primary);
+        text-decoration: none;
+        padding: 0.5rem 1rem;
+        border-radius: 8px;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: background 0.2s;
+      }
+      .week-nav a:hover {
+        background: var(--bg-tertiary);
+      }
+      .week-nav .prev { margin-right: auto; }
+      .week-nav .next { margin-left: auto; }
+      .week-nav .spacer { flex: 1; }
+      /* /week-nav-css */
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <header>
+        <h1>Logos Collective Weekly Summary</h1>
+        <p class="date">Week 32, 2026 (August 10, 2026)</p>
+      </header>
+
+      <nav class="week-nav">
+        <a class="prev" data-router-ignore href="/reports/weekly/2026-08-03.html">&larr; 2026-08-03</a>
+        <span class="spacer"></span>
+      </nav>
+
+      <div class="stats-bar">
+        <div class="stat">
+          <div class="stat-value">2</div>
+          <div class="stat-label">Teams Reporting</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">120+</div>
+          <div class="stat-label">PRs &amp; Updates</div>
+        </div>
+      </div>
+
+      <section class="highlights-section">
+        <h2>Key Highlights</h2>
+        <div class="highlights-grid">
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p><strong><a href="https://github.com/vacp2p/zerokit/releases/tag/v3.0.0">Zerokit v3.0.0 released</a></strong> &mdash; the Rust zero-knowledge library powering RLN across Logos and Status now ships with enum-based runtime configuration.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p>Published <strong><a href="https://forum.research.logos.co/t/rln-based-dos-protection-for-libp2p-mix-four-constructions/720">RLN-based DoS protection for libp2p Mix: four constructions</a></strong>, comparing four approaches to rate-limiting mixnet traffic without compromising anonymity.</p>
+          </div>
+          <div class="highlight-card anoncomms">
+            <div class="team">AnonComms</div>
+            <p>The <a href="https://lip.logos.co/anoncomms/raw/payment-streams.html">Payment Streams specification</a> now covers non-native token support in provider payment policies.</p>
+          </div>
+          <div class="highlight-card logoscore">
+            <div class="team">Logos Core</div>
+            <p><strong>Token-only handshake surface published before module initialization</strong> across the protocol, Qt SDK and capability module &mdash; one unreachable module can no longer stall startup.</p>
+          </div>
+          <div class="highlight-card logoscore">
+            <div class="team">Logos Core</div>
+            <p><code>logosctl</code> added alongside <code>logoscore</code>: one CLI for daemon, modules and packages, with install deadlines and honest failure reasons.</p>
+          </div>
+          <div class="highlight-card logoscore">
+            <div class="team">Logos Core</div>
+            <p>Storage module and UI shipped at <strong>v2.1.0</strong>; messaging modules bumped to delivery v0.2.0 / chat 0.2.2 across the release repo.</p>
+          </div>
+        </div>
+      </section>
+
+      <div class="search-box">
+        <input
+          type="text"
+          id="search"
+          placeholder="Search updates (e.g., 'Zerokit', 'RLN', 'handshake', 'logosctl', 'oracle')..."
+        />
+      </div>
+
+      <div class="tabs">
+        <button class="tab anoncomms active" data-team="anoncomms">AnonComms</button>
+        <button class="tab logoscore" data-team="logoscore">Logos Core</button>
+      </div>
+
+      <!-- ================================================================
+             ANONCOMMS
+             ================================================================ -->
+      <div class="team-content active" id="anoncomms">
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Create a basic service discovery module</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/36">Validate service discovery protocol correctness in large-scale simulations</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Fixes and improvements following test scenario issues</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Run more test scenarios</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Establish libp2p mixnet</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/51">Research more advanced cover traffic generation techniques</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Mix code improvements: <a href="https://github.com/logos-co/nim-libp2p-mix/pull/42">sender pre-send hold</a>, <a href="https://github.com/logos-co/nim-libp2p-mix/pull/45">CI drift notification</a>, <a href="https://github.com/logos-co/mix-rln-spam-protection-plugin/pull/16">harden rln-plugin against hostile input</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Analyze cover traffic strategies</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/52">Implement local reputation mechanism and research advanced DoS protection</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong>Published <a href="https://forum.research.logos.co/t/rln-based-dos-protection-for-libp2p-mix-four-constructions/720">RLN-based DoS protection for libp2p Mix: four constructions</a></strong></li>
+                  <li>Mix-RLN plugin: <a href="https://github.com/logos-co/mix-rln-spam-protection-plugin/pull/17">prune on epoch change</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Work on a local reputation mechanism (Blend/Loopix-style)</li>
+                  <li>Address review feedback on the DoS protection constructions</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Deliver de-MLS for p2p group messaging</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/63">Integrating de-MLS into libchat</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Started reworking the member-id representation</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Resolve the open discussion with libchat and finish the rework</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Implement RLN membership allocation service</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/83">Full RLN module</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>RLN module extended to handle proof generation and validation, track rate limits per membership scope, persist memberships in the keystore, and optionally use the membership allocation protocol when registering</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Finish splitting the module into a repository separate from the RLN registry repository, with proper e2e tests and module publishing</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Decentralised Oracle Network</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/56">Specifying oracle mechanism</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Review feedback addressed and alignment reached on <a href="https://github.com/logos-co/logos-lips/pull/388">PR388</a> for the proposer selection mechanism</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Merge <a href="https://github.com/logos-co/logos-lips/pull/388">PR388</a> and the short <a href="https://github.com/logos-co/logos-lips/pull/390">PR390</a> on the dispute mechanism</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/57">Implementing Oracle Zone</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>The indexer implementation can now dynamically follow and compute <code>AttestedPrice</code> per channel id and feed id</li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>LEZ registration implementation and integration in the Oracle Zone</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Implement an MVP payment protocol</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/73">Specify and implement client payment shielding via LEZ private execution mode</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Spec PR <a href="https://github.com/logos-co/logos-lips/pull/397">ready for review</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Address review feedback</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/74">Research shielding the service provider identity in the payment protocol</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Addressed in the <a href="https://github.com/logos-co/logos-lips/pull/397">same spec PR</a> as client payment shielding</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/76">Research non-native token support in provider payment policies</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li><strong><a href="https://github.com/logos-co/logos-lips/pull/379">Spec PR</a> merged</strong> &mdash; the <a href="https://lip.logos.co/anoncomms/raw/payment-streams.html">Payment Streams specification</a> now covers non-native token support</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="milestone expanded">
+          <div class="milestone-header" onclick="toggleMilestone(this)">
+            <h3>Maintain and expand Zerokit</h3>
+            <span class="milestone-toggle">^</span>
+          </div>
+          <div class="milestone-body">
+            <div class="milestone-content">
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/84">Integrate and benchmark Poseidon2 hash function</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Studied Poseidon in more detail and extended round parameters for <code>PoseidonHash</code> &mdash; <a href="https://github.com/vacp2p/zerokit/pull/433">zerokit#433</a></li>
+                </ul>
+                <span class="section-label next">Next</span>
+                <ul class="item-list">
+                  <li>Address PR comments, then move on to Poseidon2 study and implementation</li>
+                </ul>
+              </div>
+              <div class="deliverable">
+                <h4><a href="https://github.com/logos-co/anoncomms-pm/issues/86">Zerokit maintenance</a></h4>
+                <span class="section-label achieved">Achieved</span>
+                <ul class="item-list">
+                  <li>Two automated dependency bump PRs merged &mdash; <a href="https://github.com/vacp2p/zerokit/pull/431">zerokit#431</a>, <a href="https://github.com/vacp2p/zerokit/pull/434">zerokit#434</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================================================================
+             LOGOS CORE
+             ================================================================ -->
+      <div class="team-content" id="logoscore">
+        <div class="repo-list">
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-protocol">logos-protocol</a></h4>
+            <p>Token-only handshake surface published before a module initializes; failures after acquire now reported on both twins without moving the ABI, and <code>lp_invoke_async</code> can finally report a failure.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-protocol/pull/42">#42</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/41">#41</a>
+              <a href="https://github.com/logos-co/logos-protocol/pull/40">#40</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-storage-ui">logos-storage-ui</a></h4>
+            <p>Prepared for 2.1.0 with UI doctests, manifest table filters, responsive design system, simplified onboarding, better settings, and download component improvements.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/80">#80</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/79">#79</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/78">#78</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/77">#77</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/76">#76</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/75">#75</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/73">#73</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/72">#72</a>
+              <a href="https://github.com/logos-co/logos-storage-ui/pull/68">#68</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-modules-release">logos-modules-release</a></h4>
+            <p>Storage module and UI bumped to v2.1.0, messaging modules bumped to delivery v0.2.0 / chat 0.2.2 / chat-ui 0.2.2, LEZ modules and explorer/indexer bumps, and darwin metal release action fixes.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-modules-release/pull/43">#43</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/42">#42</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/40">#40</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/39">#39</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/37">#37</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/36">#36</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/35">#35</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/34">#34</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/32">#32</a>
+              <a href="https://github.com/logos-co/logos-modules-release/pull/31">#31</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-blockchain/logos-blockchain-ui">logos-blockchain-ui</a></h4>
+            <p>Design system adoption, doc tests, the node's real error surfaced instead of "Call failed", and selectable error/result text in <code>GenerateConfigView</code>.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/56">#56</a>
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/55">#55</a>
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/54">#54</a>
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/53">#53</a>
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/52">#52</a>
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/51">#51</a>
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/49">#49</a>
+              <a href="https://github.com/logos-blockchain/logos-blockchain-ui/pull/46">#46</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-rust-sdk">logos-rust-sdk</a></h4>
+            <p>Typed event emitters now speak records, <code>Option&lt;T&gt;</code> parameters in the Rust-first frontend, <code>Option&lt;serde_json::Value&gt;</code> admitted, and per-call timeout entry points on the generated client.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/38">#38</a>
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/37">#37</a>
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/36">#36</a>
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/35">#35</a>
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/34">#34</a>
+              <a href="https://github.com/logos-co/logos-rust-sdk/pull/32">#32</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-module-builder">logos-module-builder</a></h4>
+            <p>SDK stack re-pinned so logos-protocol is 0f26ffd everywhere, handshake surface bumps, and a <code>.#ui-dev</code> binary that hot reloads live QML changes for rapid UI development.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-module-builder/pull/189">#189</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/188">#188</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/187">#187</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/186">#186</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/183">#183</a>
+              <a href="https://github.com/logos-co/logos-module-builder/pull/182">#182</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-qt-sdk">logos-qt-sdk</a></h4>
+            <p>Optional PARAMETERS on every Qt surface with <code>-&gt; ?T</code> refused, handshake surface published before the initializer runs, and <code>jsonReturn</code> shapes no longer double-converted.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/31">#31</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/30">#30</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/29">#29</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/28">#28</a>
+              <a href="https://github.com/logos-co/logos-qt-sdk/pull/27">#27</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-cpp-sdk">logos-cpp-sdk</a></h4>
+            <p>Generator hardening: async callers see the error and sync callers can set a deadline, unread STRUCTURE in a record is now a build error, and the Qt consumer no longer flattens a rejection into an empty value.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/133">#133</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/132">#132</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/131">#131</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/130">#130</a>
+              <a href="https://github.com/logos-co/logos-cpp-sdk/pull/129">#129</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-test-modules">logos-test-modules</a></h4>
+            <p>Record event emitter now typed (pass the Blob, not its JSON), plus three conformance sweeps correcting prose that contradicted its own cells.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-test-modules/pull/43">#43</a>
+              <a href="https://github.com/logos-co/logos-test-modules/pull/42">#42</a>
+              <a href="https://github.com/logos-co/logos-test-modules/pull/41">#41</a>
+              <a href="https://github.com/logos-co/logos-test-modules/pull/40">#40</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-logoscore-py">logos-logoscore-py</a></h4>
+            <p>A second Python client for <code>logosctl</code> with its own parallel suite; an expectation key the driver ignores now fails the run; top-level <code>None</code> treated as the empty optional.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/19">#19</a>
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/18">#18</a>
+              <a href="https://github.com/logos-co/logos-logoscore-py/pull/17">#17</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-storage-module">logos-storage-module</a></h4>
+            <p>Prepared for the 2.1.0 release with logos-storage-nim updated to v0.4.2.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-storage-module/pull/74">#74</a>
+              <a href="https://github.com/logos-co/logos-storage-module/pull/73">#73</a>
+              <a href="https://github.com/logos-co/logos-storage-module/pull/72">#72</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-blockchain/lez-explorer-ui">lez-explorer-ui</a></h4>
+            <p>Channel id changes now take effect properly; modules bumped for 0.2.3 with auto-start on launch and a prettified settings page.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-blockchain/lez-explorer-ui/pull/19">#19</a>
+              <a href="https://github.com/logos-blockchain/lez-explorer-ui/pull/17">#17</a>
+              <a href="https://github.com/logos-blockchain/lez-explorer-ui/pull/16">#16</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui">logos-execution-zone-wallet-ui</a></h4>
+            <p>Latest design system adopted with UI compatibility updates, bumped to 1.1.0, and improved private account listing.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/38">#38</a>
+              <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/35">#35</a>
+              <a href="https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/30">#30</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-basecamp">logos-basecamp</a></h4>
+            <p>Uninstall app option added in AppManager, plus persistence portability and missing dependency tests.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-basecamp/pull/317">#317</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/312">#312</a>
+              <a href="https://github.com/logos-co/logos-basecamp/pull/310">#310</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-logoscore-cli">logos-logoscore-cli</a></h4>
+            <p><code>logosctl</code> added alongside <code>logoscore</code> as one CLI for daemon, modules and packages; install deadline, honest failure reasons, and a <code>-v</code> that actually reaches the daemon.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/83">#83</a>
+              <a href="https://github.com/logos-co/logos-logoscore-cli/pull/76">#76</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-module-loader-qt">logos-module-loader-qt</a></h4>
+            <p>Host now owns where its logging goes instead of letting Qt choose; logos-protocol pinned to 0f26ffd.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-module-loader-qt/pull/6">#6</a>
+              <a href="https://github.com/logos-co/logos-module-loader-qt/pull/5">#5</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-liblogos">logos-liblogos</a></h4>
+            <p>logos-protocol pinned to 0f26ffd with CI moved off Nix 2.22; module loader bumped for the host logging fix.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-liblogos/pull/174">#174</a>
+              <a href="https://github.com/logos-co/logos-liblogos/pull/173">#173</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-doctest">logos-doctest</a></h4>
+            <p>Nix flags injected to the left of a <code>--</code> rather than into the app's argv; UI test pre-builds the app attribute <code>nix run</code> will execute.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-doctest/pull/13">#13</a>
+              <a href="https://github.com/logos-co/logos-doctest/pull/11">#11</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-workspace">logos-workspace</a></h4>
+            <p>CI bumped from install-nix-action v27 to v31.11.0 (Nix 2.22 &rarr; 2.35.1); handshake-surface landing pinned across 4 repos.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-workspace/pull/100">#100</a>
+              <a href="https://github.com/logos-co/logos-workspace/pull/99">#99</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-standalone-app">logos-standalone-app</a></h4>
+            <p>logos-liblogos and logos-cpp-sdk re-pinned onto merged masters at protocol 0f26ffd.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-standalone-app/pull/34">#34</a>
+              <a href="https://github.com/logos-co/logos-standalone-app/pull/33">#33</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-chat-module">logos-chat-module</a></h4>
+            <p>Delivery preset defaulted to logos.test; 0.2.2 prepared against <code>delivery_module</code> v0.2.0.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-chat-module/pull/64">#64</a>
+              <a href="https://github.com/logos-co/logos-chat-module/pull/63">#63</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-evm-wallet-ui">logos-evm-wallet-ui</a></h4>
+            <p>Each UI doc-test run given its own session directory; module-builder bumped to the latest SDK stack.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-evm-wallet-ui/pull/23">#23</a>
+              <a href="https://github.com/logos-co/logos-evm-wallet-ui/pull/11">#11</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-capability-module">logos-capability-module</a></h4>
+            <p>Token push bounded at startup so one unreachable module cannot stall startup.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-capability-module/pull/22">#22</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-plugin-qt">logos-plugin-qt</a></h4>
+            <p>A failing logos-cpp-generator must now fail the build.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-plugin-qt/pull/16">#16</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-delivery-module">logos-delivery-module</a></h4>
+            <p>Run-node guide and shipped configs moved to the layered <code>createNode</code> shape.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-delivery-module/pull/82">#82</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-chat-ui">logos-chat-ui</a></h4>
+            <p>0.2.2 prepared against <code>chat_module</code> 0.2.2 and <code>delivery_module</code> v0.2.0.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-chat-ui/pull/54">#54</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-design-system">logos-design-system</a></h4>
+            <p>Logos artwork and apptile added.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-design-system/pull/48">#48</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4><a href="https://github.com/logos-co/logos-view-module-runtime">logos-view-module-runtime</a></h4>
+            <p>logos-protocol pinned to 0f26ffd.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-view-module-runtime/pull/19">#19</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4>EVM modules</h4>
+            <p><code>logos-evm-eth-rpc-module</code>, <code>logos-evm-railgun-module</code>, <code>logos-evm-uniswap-module</code> and <code>logos-evm-wallet-backend-module</code> all bumped to the latest SDK stack.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/logos-evm-eth-rpc-module/pull/6">eth-rpc#6</a>
+              <a href="https://github.com/logos-co/logos-evm-railgun-module/pull/3">railgun#3</a>
+              <a href="https://github.com/logos-co/logos-evm-uniswap-module/pull/5">uniswap#5</a>
+              <a href="https://github.com/logos-co/logos-evm-wallet-backend-module/pull/10">wallet-backend#10</a>
+            </div>
+          </div>
+
+          <div class="repo-card">
+            <h4>nix bundlers</h4>
+            <p>The <code>ld.so</code> trampoline dropped in favour of setting the psABI interpreter directly, with AppImage, <code>.lgx</code> and macOS <code>.app</code> outputs each gated on a smoke test.</p>
+            <div class="pr-list">
+              <a href="https://github.com/logos-co/nix-bundle-dir/pull/18">bundle-dir#18</a>
+              <a href="https://github.com/logos-co/nix-bundle-appimage/pull/5">appimage#5</a>
+              <a href="https://github.com/logos-co/nix-bundle-lgx/pull/9">lgx#9</a>
+              <a href="https://github.com/logos-co/nix-bundle-macos-app/pull/5">macos-app#5</a>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <footer>
+        <p>Generated from weekly updates | Logos Collective Roadmap</p>
+      </footer>
+    </div>
+    <script>
+      // Tab switching
+      document.querySelectorAll(".tab").forEach((tab) => {
+        tab.addEventListener("click", () => {
+          const team = tab.dataset.team
+
+          document.querySelectorAll(".tab").forEach((t) => t.classList.remove("active"))
+          document.querySelectorAll(".team-content").forEach((c) => c.classList.remove("active"))
+
+          tab.classList.add("active")
+          document.getElementById(team).classList.add("active")
+        })
+      })
+
+      // Milestone toggle
+      function toggleMilestone(header) {
+        const milestone = header.closest(".milestone")
+        milestone.classList.toggle("expanded")
+      }
+
+      // Search functionality
+      const searchInput = document.getElementById("search")
+      searchInput.addEventListener("input", (e) => {
+        const searchTerm = e.target.value.toLowerCase()
+        const allContent = document.querySelectorAll(".milestone, .deliverable, .repo-card")
+
+        allContent.forEach((element) => {
+          const text = element.textContent.toLowerCase()
+          if (text.includes(searchTerm) || searchTerm === "") {
+            element.style.display = ""
+          } else {
+            element.style.display = "none"
+          }
+        })
+      })
+
+      // Keyboard navigation
+      document.addEventListener("keydown", (e) => {
+        if (e.ctrlKey || e.metaKey) {
+          const tabs = Array.from(document.querySelectorAll(".tab"))
+          const activeIndex = tabs.findIndex((t) => t.classList.contains("active"))
+
+          if (e.key === "ArrowLeft" && activeIndex > 0) {
+            e.preventDefault()
+            tabs[activeIndex - 1].click()
+          } else if (e.key === "ArrowRight" && activeIndex < tabs.length - 1) {
+            e.preventDefault()
+            tabs[activeIndex + 1].click()
+          }
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/content/reports/weekly/index.md
+++ b/content/reports/weekly/index.md
@@ -3,6 +3,7 @@ title: Weekly Reports
 ---
 This directory contains all the weekly files in a linkable fashion.
 
+- <a href="/reports/weekly/2026-07-20.html" data-router-ignore>2026-07-20</a>
 - <a href="/reports/weekly/2026-07-13.html" data-router-ignore>2026-07-13</a>
 - <a href="/reports/weekly/2026-07-06.html" data-router-ignore>2026-07-06</a>
 - <a href="/reports/weekly/2026-06-29.html" data-router-ignore>2026-06-29</a>

--- a/content/reports/weekly/index.md
+++ b/content/reports/weekly/index.md
@@ -3,6 +3,9 @@ title: Weekly Reports
 ---
 This directory contains all the weekly files in a linkable fashion.
 
+- <a href="/reports/weekly/2026-08-10.html" data-router-ignore>2026-08-10</a>
+- <a href="/reports/weekly/2026-08-03.html" data-router-ignore>2026-08-03</a>
+- <a href="/reports/weekly/2026-07-27.html" data-router-ignore>2026-07-27</a>
 - <a href="/reports/weekly/2026-07-20.html" data-router-ignore>2026-07-20</a>
 - <a href="/reports/weekly/2026-07-13.html" data-router-ignore>2026-07-13</a>
 - <a href="/reports/weekly/2026-07-06.html" data-router-ignore>2026-07-06</a>


### PR DESCRIPTION
Adds the aggregated cross-team weekly summaries under `content/reports/weekly/` for the weeks of 2026-07-20 through 2026-08-10, built from the per-team markdown updates in `content/<team>/updates/`.

These are the HTML rollup artifacts described in `content/reports/weekly/README.md` — a separate artifact from the per-team weeklies, which is why there is no overlap with the update PRs already merged.

## What's here

| Report | Teams | Notes |
|---|---|---|
| `2026-07-20.html` (Week 29) | 5 | New file on v5; Blockchain section backfilled |
| `2026-07-27.html` (Week 30) | 5 | New |
| `2026-08-03.html` (Week 31) | 4 | New — no logoscore update for this week |
| `2026-08-10.html` (Week 32) | 2 | New — anoncomms + logoscore only |

The 07-20 report was originally written before `content/blockchain/updates/2026-07-20.md` landed, so it shipped with 4 teams and "no blockchain this week". That section is now filled in and the stats/highlights updated to match.

Each report's tab set matches exactly the team update files that exist for that date. Where a team has no update for a week, it simply has no tab — that reflects the source material rather than a gap in the rollup.

## Coverage highlights

- **Messaging** — QUIC passed DST scale validation; RLN-sourced rate limiting enforced in the send service; `logos-delivery-module` v0.2.0; SDS reliability live in Status Communities
- **Blockchain** — Channel Participation in PoS LIP merged; Post-Quantum Safety Analysis of Bedrock finalized; multi-sequencer support across the LEZ stack; LEZ v0.2.1
- **AnonComms** — oracle mechanism spec published as a LIP; Zerokit v3.0.0 released and the deliverable closed; RLN-based DoS protection for libp2p Mix published
- **Storage** — "When Mixnets Fail" path selection simulations in `hs-mix-sim`; storage module v2.1.0; Kad-DHT migration greenlit
- **Logos Core** — multi-user daemon support; token-only handshake surface; `logosctl` added alongside `logoscore`

## Verification

- Nav `prev`/`next` chain runs unbroken from 07-13 through 08-10
- `index.md` updated with `data-router-ignore` links, per the template README's SPA-router requirement
- All six reports pass an HTML parser check: tag balance, exactly one active tab and one active `team-content` per file, and every tab's `data-team` has a matching content `id`

## ⚠️ Build not verified

I could not run a full site build on this branch. On v5, `npm run install-plugins` fails with:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".scss"
  for quartz/styles/base.scss
```

I confirmed this is **pre-existing and unrelated to these changes** by stashing everything and rerunning against a pristine `origin/v5` tree — it fails identically. It appears to be a v5 toolchain issue in the plugin loader (`tsx` not resolving the scss import).

The reports are static HTML that Quartz copies verbatim, so their correctness does not depend on that pipeline, but a reviewer who can get the build running should confirm the pages render and the tabs work.

## Note on source dates

Storage's weeklies carry frontmatter dates one week behind their filenames (`2026-07-27.md` has `date: 2026-07-20`, headed "Week 30 … Jul 20-24"), and logoscore files its week-of-07-20 update as `2026-07-21.md`. I keyed off filenames, consistent with the README's "use the date of the week's end" and with how the earlier backfills were done. Worth a sanity check if that convention is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)