### PR TITLE
docs(blockchain): add weekly update 2026-08-17

### DIFF
--- a/content/blockchain/updates/2026-08-10.md
+++ b/content/blockchain/updates/2026-08-10.md
@@ -3,7 +3,7 @@ title: 2026-08-10 Logos Blockchain weekly
 tags:
   - blockchain-updates
 date: 2026-08-10
-lastmod: 2026-08-10
+lastmod: 2026-08-19
 draft: false
 description: Weekly update of Logos Blockchain
 ---
@@ -64,6 +64,9 @@ description: Weekly update of Logos Blockchain
 
 - `blockchain:bedrock:eng:zone-sdk`
   - λSQL architecture proposal written, layering decentralized SQL databases over the Zone SDK [doc](https://app.notion.com/p/nomos-tech/SQL-rs-architecture-proposal-3ae261aa09df80298c00edc15e006c9d)
+  - Indexer removed in favor of the sequencer for reads and writes [#3220](https://github.com/logos-blockchain/logos-blockchain/pull/3220); `FundingConfig` made mandatory [#3239](https://github.com/logos-blockchain/logos-blockchain/pull/3239)
+  - Zone SDK fixes merged: pending inscriptions invalidated on config update [#3237](https://github.com/logos-blockchain/logos-blockchain/pull/3237), tip reset on config-update key index and round-robin turn [#3264](https://github.com/logos-blockchain/logos-blockchain/pull/3264), correct tip on bundled custom transactions [#3256](https://github.com/logos-blockchain/logos-blockchain/pull/3256), flaky deposit and integration tests [#3254](https://github.com/logos-blockchain/logos-blockchain/pull/3254), [#3277](https://github.com/logos-blockchain/logos-blockchain/pull/3277)
+  - Channel wallet tracker per the new channel-notes model (in-review) [#3246](https://github.com/logos-blockchain/logos-blockchain/pull/3246)
 
 - `blockchain:bedrock:eng:logos-core`
   - Node 0.2.1 testnet release published [release](https://github.com/logos-blockchain/logos-blockchain/releases/tag/0.2.1): fleet deployed, module and UI released, with a UI deployment-config loading bug fixed and re-released

--- a/content/blockchain/updates/2026-08-17.md
+++ b/content/blockchain/updates/2026-08-17.md
@@ -12,7 +12,7 @@ description: Weekly update of Logos Blockchain
 
 ## `blockchain:highlights`
 
-- **Uncle references merged across the node** [#3281](https://github.com/logos-blockchain/logos-blockchain/pull/3281), [#3282](https://github.com/logos-blockchain/logos-blockchain/pull/3282), [#3283](https://github.com/logos-blockchain/logos-blockchain/pull/3283), [#3284](https://github.com/logos-blockchain/logos-blockchain/pull/3284), [#3285](https://github.com/logos-blockchain/logos-blockchain/pull/3285)
+- **Cryptarchia Blocks now have Uncle Refs, leading to much more stable Total Stake Inference** [#3281](https://github.com/logos-blockchain/logos-blockchain/pull/3281), [#3282](https://github.com/logos-blockchain/logos-blockchain/pull/3282), [#3283](https://github.com/logos-blockchain/logos-blockchain/pull/3283), [#3284](https://github.com/logos-blockchain/logos-blockchain/pull/3284), [#3285](https://github.com/logos-blockchain/logos-blockchain/pull/3285)
 - **Node 0.2.2 released** with the wallet double-note fix [release](https://github.com/logos-blockchain/logos-blockchain/releases/tag/0.2.2), [#3287](https://github.com/logos-blockchain/logos-blockchain/pull/3287)
 - **Logos Execution Zone decentralized sequencing landed: sequencer self-join** [#653](https://github.com/logos-blockchain/logos-execution-zone/pull/653) **and libp2p gossip module** [#662](https://github.com/logos-blockchain/logos-execution-zone/pull/662)
 - **Nimbos block rewards and block body validation merged** [nimbos#155](https://github.com/logos-co/nimbos/pull/155), [nimbos#142](https://github.com/logos-co/nimbos/pull/142)

--- a/content/blockchain/updates/2026-08-17.md
+++ b/content/blockchain/updates/2026-08-17.md
@@ -1,0 +1,109 @@
+---
+title: 2026-08-17 Logos Blockchain weekly
+tags:
+  - blockchain-updates
+date: 2026-08-17
+lastmod: 2026-08-17
+draft: false
+description: Weekly update of Logos Blockchain
+---
+
+# Logos Blockchain Weekly Update - 2026-08-17
+
+## `blockchain:highlights`
+
+- **Uncle references merged across the node** [#3281](https://github.com/logos-blockchain/logos-blockchain/pull/3281), [#3282](https://github.com/logos-blockchain/logos-blockchain/pull/3282), [#3283](https://github.com/logos-blockchain/logos-blockchain/pull/3283), [#3284](https://github.com/logos-blockchain/logos-blockchain/pull/3284), [#3285](https://github.com/logos-blockchain/logos-blockchain/pull/3285)
+- **Node 0.2.2 released** with the wallet double-note fix [release](https://github.com/logos-blockchain/logos-blockchain/releases/tag/0.2.2), [#3287](https://github.com/logos-blockchain/logos-blockchain/pull/3287)
+- **Logos Execution Zone decentralized sequencing landed: sequencer self-join** [#653](https://github.com/logos-blockchain/logos-execution-zone/pull/653) **and libp2p gossip module** [#662](https://github.com/logos-blockchain/logos-execution-zone/pull/662)
+- **Nimbos block rewards and block body validation merged** [nimbos#155](https://github.com/logos-co/nimbos/pull/155), [nimbos#142](https://github.com/logos-co/nimbos/pull/142)
+
+## `blockchain:bedrock:research`
+
+- `blockchain:bedrock:research:cryptarchia`
+  - Uncle references RFC revised: reference window retuned to W = 12 and `body_root` flattened over the serialized uncle list (in-review) [logos-lips#385](https://github.com/logos-co/logos-lips/pull/385)
+  - Compressed Block Proposal LIP revised: transaction reference prefix moved to 16 bytes after identifying birthday self-collision as the governing attack, collision-handling machinery removed (in-review) [logos-lips#389](https://github.com/logos-co/logos-lips/pull/389)
+  - All note-consuming operations now reject empty inputs: spec [logos-lips#399](https://github.com/logos-co/logos-lips/pull/399), node [#3298](https://github.com/logos-blockchain/logos-blockchain/pull/3298)
+
+- `blockchain:bedrock:research:total-stake-inference`
+  - Uncle-reference verification depth bounded via a parent-anchored window (W = 12, with 11.5 ruled out), adversary coalition sizing fixed, and four simulator defects repaired (in-review) [research#4](https://github.com/logos-blockchain/research/pull/4)
+
+- `blockchain:bedrock:research:empowering`
+  - Bedrock RFC enabling the basic EmPoWering machinery opened (draft): Proof of Work parameters calibrated (claim target, distribution rate, Blend admission threshold), TGE supply sized, token denomination settled, reward pool funded from fee inflow [logos-lips#400](https://github.com/logos-co/logos-lips/pull/400)
+  - Tokenomics simulations and report: sweep programme and validation figures, results re-derived at lepton granularity, threshold calibrated on measured Raspberry Pi 5 hardware (in-review) [research#5](https://github.com/logos-blockchain/research/pull/5)
+  - Stochastic model of the epoch reward pool derived (binomial blocks per epoch, log-normal fee revenue, Poisson claims): mean recovers the deterministic equation, variance settles to a lower equilibrium value [doc](https://app.notion.com/p/nomos-tech/EmPoWering-Analysis-of-Economics-3bd261aa09df80fcafc6c3cd3d0b6820)
+
+- `blockchain:bedrock:research:post-quantum`
+  - Post-Quantum primitive benchmark moved to the research repo with sender/receiver asymmetry under load (in-review) [research#3](https://github.com/logos-blockchain/research/pull/3); benchmark document reworked with stress-test results across four platforms [doc](https://app.notion.com/p/nomos-tech/Post-Quantum-Primitive-Benchmarks-390261aa09df80ad826ed884620222ce); new dashboard completed [dashboard](https://logos-blockchain.github.io/research/pqc/)
+  - Post-Quantum Migration Strategy for the Logos stack drafted (WIP) [doc](https://app.notion.com/p/nomos-tech/Post-Quantum-Migration-Strategy-for-the-Logos-Stack-3bc261aa09df80e19946dbaccea66aea)
+
+- `blockchain:bedrock:research:anonymous-communications`
+  - Mix-net configuration recommended against stake inference and Bayesian inference attacks, with its guarantees extended from one epoch to many epochs and across network sizes [doc](https://app.notion.com/p/nomos-tech/Mixnet-recommendation-the-proposed-configuration-and-its-guarantees-over-time-and-network-size-f92261aa09df8322a6198142b0acef9b)
+  - Random regular graph mix-net Bayesian attribution attack implemented across connectivity, corruption, and path-length parameters, compared with the stratified mix-net, and run inside a stake-weighted simulation [doc](https://app.notion.com/p/nomos-tech/RRG-Mixnet-connectivity-stratified-mixnet-comparison-and-stake-derived-simulation-3bf261aa09df80e99e3ef2b6d1ae8d79)
+
+- `blockchain:bedrock:research:cross-zone-sequencing`
+  - Costly Abort Mechanism demo hardened: transaction binding, participant-owned key registration, signature validation, timeout handling, and fee-proof verification; optimistic dispute flow refined so the normal path needs no routine confirmation [code](https://github.com/Warrenhimself/logos-execution-zone/tree/cacp-protocol); RFC being restructured into a single-path developer-facing specification (WIP) [doc](https://app.notion.com/p/nomos-tech/LEZ-CACP-Costly-Abort-Bond-Protocol-3ab261aa09df80c88844f4edd21e19de)
+
+## `blockchain:bedrock:eng`
+
+- `blockchain:bedrock:eng:security-audit`
+  - Compressed merkle-tree recovery bounded [#3247](https://github.com/logos-blockchain/logos-blockchain/pull/3247)
+
+- `blockchain:bedrock:eng:blend`
+  - Proof of Quota verification re-introduced before relaying messages, with peers sending invalid proofs marked spammy and banned [#3292](https://github.com/logos-blockchain/logos-blockchain/pull/3292)
+  - Epoch-transition bug fixed: unreleased block proposals are forwarded to old-epoch peers instead of being carried into the new epoch with a stale Proof of Quota [#3304](https://github.com/logos-blockchain/logos-blockchain/pull/3304)
+  - Proof of Quota circuit bumped to v0.5.6, Proof of Work secret key and block hash replaced with a `pow_nonce` and domain-separation tag [logos-blockchain-circuits#54](https://github.com/logos-blockchain/logos-blockchain-circuits/pull/54), [#3305](https://github.com/logos-blockchain/logos-blockchain/pull/3305)
+  - Public header verification benchmarks merged [#3278](https://github.com/logos-blockchain/logos-blockchain/pull/3278)
+  - Proof of Work proof generator (in-review) [#3310](https://github.com/logos-blockchain/logos-blockchain/pull/3310); transaction density tracked for epoch-bound Blend difficulty updates (in-review) [#3317](https://github.com/logos-blockchain/logos-blockchain/pull/3317)
+
+- `blockchain:bedrock:eng:node`
+  - Uncle references merged across the stack: uncle headers carried and committed by `body_root` [#3281](https://github.com/logos-blockchain/logos-blockchain/pull/3281), reference window in config [#3282](https://github.com/logos-blockchain/logos-blockchain/pull/3282), uncle selection when proposing [#3283](https://github.com/logos-blockchain/logos-blockchain/pull/3283), uncle verification when applying blocks [#3284](https://github.com/logos-blockchain/logos-blockchain/pull/3284), uncles counted in Total Stake Inference [#3285](https://github.com/logos-blockchain/logos-blockchain/pull/3285); header validation reused for uncle validation [#3314](https://github.com/logos-blockchain/logos-blockchain/pull/3314)
+  - Gas constants redesigned for the SignedOp flow merged [#3273](https://github.com/logos-blockchain/logos-blockchain/pull/3273); op codes moved onto the operations themselves (in-review) [#3308](https://github.com/logos-blockchain/logos-blockchain/pull/3308)
+  - Priority fee changed to a percentage [#3311](https://github.com/logos-blockchain/logos-blockchain/pull/3311)
+  - Leadership log spam reduced [#3253](https://github.com/logos-blockchain/logos-blockchain/pull/3253)
+  - HTTP endpoint returning the running node's binary version, also shown per bootstrap node on `/web` (in-review) [#3296](https://github.com/logos-blockchain/logos-blockchain/pull/3296)
+
+- `blockchain:bedrock:eng:testing`
+  - Testing Framework: genesis time made cluster-scoped and configurable [#3312](https://github.com/logos-blockchain/logos-blockchain/pull/3312); managed Kubernetes node control (in-review) [logos-blockchain-testing#62](https://github.com/logos-blockchain/logos-blockchain-testing/pull/62); core/local test coverage and CI workflow (in-review) [logos-blockchain-testing#63](https://github.com/logos-blockchain/logos-blockchain-testing/pull/63)
+  - Block-proposal tracing build for deterministic simulation runs, capturing proposal time, Blend exit, and libp2p receipt of the same block [image](https://github.com/logos-blockchain/logos-blockchain/pkgs/container/logos-blockchain/1121152202?tag=0.2.2-dst-block-tracing)
+
+- `blockchain:bedrock:eng:zone-sdk`
+  - Deposit events extended with public-key information for channel wallet tracking [#3299](https://github.com/logos-blockchain/logos-blockchain/pull/3299); refund of transactions on timeout prototyped (draft) [#3289](https://github.com/logos-blockchain/logos-blockchain/pull/3289)
+  - λSQL local replication flow started (in-review) [#3322](https://github.com/logos-blockchain/logos-blockchain/pull/3322)
+
+- `blockchain:bedrock:eng:logos-core`
+  - Node 0.2.2 released [release](https://github.com/logos-blockchain/logos-blockchain/releases/tag/0.2.2), fixing the wallet handing out a double note when funding during the non-finalized window [#3287](https://github.com/logos-blockchain/logos-blockchain/pull/3287); blockchain module 0.2.2 released [logos-modules-release#44](https://github.com/logos-co/logos-modules-release/pull/44)
+
+## `blockchain:logos-execution-zone`
+
+- `blockchain:logos-execution-zone:sequencer`
+  - Sequencer self-join merged, with genesis actions and channel creation from config plus genesis block so channels can start with multiple accredited keys [#653](https://github.com/logos-blockchain/logos-execution-zone/pull/653)
+  - Sequencer libp2p gossip module merged [#662](https://github.com/logos-blockchain/logos-execution-zone/pull/662)
+  - Sequencer join/exit queues, with config operations valid only once the triggering Logos Execution Zone block is finalized (in-review) [#725](https://github.com/logos-blockchain/logos-execution-zone/pull/725); slashing basic plumbing (draft) [#737](https://github.com/logos-blockchain/logos-execution-zone/pull/737); fault taxonomy started (WIP) [doc](https://app.notion.com/p/WIP-Fault-taxonomy-3bb8f96fb65c80188b43eeaed7a55fb9)
+  - Actor architecture phase 1 merged: RpcServer and Executor actors [#691](https://github.com/logos-blockchain/logos-execution-zone/pull/691); phase 2 Storage actor (draft) [#736](https://github.com/logos-blockchain/logos-execution-zone/pull/736)
+  - Wallet FFI transaction status polling merged [#696](https://github.com/logos-blockchain/logos-execution-zone/pull/696) and exposed in the Logos Execution Zone module [logos-execution-zone-module#50](https://github.com/logos-blockchain/logos-execution-zone-module/pull/50); multi-sequencer support in the wallet CLI (in-review) [#703](https://github.com/logos-blockchain/logos-execution-zone/pull/703), FFI (in-review) [#715](https://github.com/logos-blockchain/logos-execution-zone/pull/715), and module (in-review) [logos-execution-zone-module#51](https://github.com/logos-blockchain/logos-execution-zone-module/pull/51)
+  - Wallet and wallet FFI defects triaged into six issues: sync panic on notes to unknown identifiers [#724](https://github.com/logos-blockchain/logos-execution-zone/issues/724), decrypted notes accepted without checking transaction commitments [#727](https://github.com/logos-blockchain/logos-execution-zone/issues/727), private-transfer panics [#728](https://github.com/logos-blockchain/logos-execution-zone/issues/728), wrong FFI identifier and receive-model docs [#729](https://github.com/logos-blockchain/logos-execution-zone/issues/729), missing FFI unwind boundary [#730](https://github.com/logos-blockchain/logos-execution-zone/issues/730), misleading private-transfer result envelope [logos-execution-zone-module#52](https://github.com/logos-blockchain/logos-execution-zone-module/issues/52)
+
+- `blockchain:logos-execution-zone:fees`
+  - Fee subsystem design started: `Vault::Claim` decided fee-exempt with zero-amount claims rejected; protocol-level reference prototype (draft) [#706](https://github.com/logos-blockchain/logos-execution-zone/pull/706)
+
+- `blockchain:logos-execution-zone:cross-zone`
+  - Generalization Phase 1: outbox slots made write-once log entries keyed by emitter [#697](https://github.com/logos-blockchain/logos-execution-zone/pull/697), outbox pinned in emitters and `bridge_lock` mint destination [#699](https://github.com/logos-blockchain/logos-execution-zone/pull/699), deliveries authorized at the target instead of the inbox [#700](https://github.com/logos-blockchain/logos-execution-zone/pull/700); target peer sources updatable by a named authority (in-review) [#712](https://github.com/logos-blockchain/logos-execution-zone/pull/712); pending dispatches stored as per-message entries (in-review) [#718](https://github.com/logos-blockchain/logos-execution-zone/pull/718)
+  - Phase 2 started: one peer-block acceptance policy for watcher and verifier (in-review) [#721](https://github.com/logos-blockchain/logos-execution-zone/pull/721); verification halts made durable, diagnosable, and recoverable (in-review) [#731](https://github.com/logos-blockchain/logos-execution-zone/pull/731)
+
+- `blockchain:logos-execution-zone:accounts`
+  - Environment unification functionally complete: private authorization key merged [#669](https://github.com/logos-blockchain/logos-execution-zone/pull/669); balance spends always authorized (in-review) [#726](https://github.com/logos-blockchain/logos-execution-zone/pull/726), protocol-wide `Clear` instruction (in-review) [#732](https://github.com/logos-blockchain/logos-execution-zone/pull/732), permissionless claims (in-review) [#734](https://github.com/logos-blockchain/logos-execution-zone/pull/734)
+  - Events implemented end to end (in-review): events field and core semantics [#705](https://github.com/logos-blockchain/logos-execution-zone/pull/705), EVM-style protocol-level selectors [#707](https://github.com/logos-blockchain/logos-execution-zone/pull/707), indexer re-derivation from seen blocks [#709](https://github.com/logos-blockchain/logos-execution-zone/pull/709), RPC [#713](https://github.com/logos-blockchain/logos-execution-zone/pull/713) and FFI [#714](https://github.com/logos-blockchain/logos-execution-zone/pull/714), deposit/withdraw events [#716](https://github.com/logos-blockchain/logos-execution-zone/pull/716)
+  - Programs as accounts started, toward programs deployable through public transactions (in-review): `programs` shape [#720](https://github.com/logos-blockchain/logos-execution-zone/pull/720), `program_owner` as `AccountId` [#722](https://github.com/logos-blockchain/logos-execution-zone/pull/722), program storage folded into `public_state` [#723](https://github.com/logos-blockchain/logos-execution-zone/pull/723), `ProgramId` references removed from chaincalls [#735](https://github.com/logos-blockchain/logos-execution-zone/pull/735), `Deploy` program transaction [#733](https://github.com/logos-blockchain/logos-execution-zone/pull/733); optimizations to remove practical blockers (draft) [#738](https://github.com/logos-blockchain/logos-execution-zone/pull/738), [#739](https://github.com/logos-blockchain/logos-execution-zone/pull/739), [#740](https://github.com/logos-blockchain/logos-execution-zone/pull/740)
+  - Program updates implementation started (draft) [#710](https://github.com/logos-blockchain/logos-execution-zone/pull/710), [#711](https://github.com/logos-blockchain/logos-execution-zone/pull/711)
+  - Consistent domain separators introduced across the key protocol (in-review) [#717](https://github.com/logos-blockchain/logos-execution-zone/pull/717)
+
+- `blockchain:logos-execution-zone:testing`
+  - Multi-sequencer support for integration tests merged [#643](https://github.com/logos-blockchain/logos-execution-zone/pull/643)
+  - Cucumber environment on top of the Testing Framework with initial ported integration tests (in-review) [#741](https://github.com/logos-blockchain/logos-execution-zone/pull/741)
+
+## `nimbos`
+
+- Block rewards merged [nimbos#155](https://github.com/logos-co/nimbos/pull/155)
+- Block body validation merged into `unstable` [nimbos#142](https://github.com/logos-co/nimbos/pull/142)
+- Mempool and block proposal finalized (in-review) [nimbos#143](https://github.com/logos-co/nimbos/pull/143); Bedrock specification tags upgraded (in-review) [nimbos#165](https://github.com/logos-co/nimbos/pull/165)
+- nim-bincode made fully compatible with the nim-serialization API (`Bincode`, `BincodeReader`, `BincodeWriter`, `deriveBincodeCustom`) [code](https://github.com/aimendj/nim-bincode); serialization migrated across the codebase toward libp2p GossipSub (WIP) [code](https://github.com/logos-co/nimbos/tree/feat/p2p-gossipsub)


### PR DESCRIPTION
Weekly update for the window 2026-08-10..2026-08-16.

Highlights: uncle references merged across the node, Node 0.2.2 released, LEZ sequencer self-join and gossip module merged, Nimbos block rewards and block body validation merged.

Also backfills zone-sdk merges from 2026-08-03..08-09 into the 2026-08-10 report (that contributor's update was posted late and missed last week's window).

PR statuses are as of end-of-window (2026-08-16): PRs merged 08-17 or later are reported as in-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)