### PR TITLE
docs(logoscore): add weekly update 2026-08-31

### DIFF
--- a/content/logoscore/updates/2026-08-31.md
+++ b/content/logoscore/updates/2026-08-31.md
@@ -1,0 +1,366 @@
+---
+title: "2026-08-31 Logoscore Weekly"
+---
+
+# Logoscore Weekly Update — 2026-08-31
+
+## Highlights
+
+- **A module can ask for a signature; only a human can produce one.** The keystore's unlocked-signer cache is gone — `unlock`, `lock` and every `sign_*` were deleted from the contract rather than gated, the key is now derived from the vault password *inside* `approve()` and zeroized before the call returns, and admission is tiered by caller identity. The wallet backend became a pure requester, the wallet UI stopped handling the vault password, and `signer_ui` was proven end-to-end against a live secp256k1 signature that exists only because a password was typed into it [logos-evm-keystore-module#6](https://github.com/logos-co/logos-evm-keystore-module/pull/6), [logos-evm-signer-ui#2](https://github.com/logos-co/logos-evm-signer-ui/pull/2), [logos-evm-wallet-backend-module#12](https://github.com/logos-co/logos-evm-wallet-backend-module/pull/12), [logos-evm-wallet-ui#25](https://github.com/logos-co/logos-evm-wallet-ui/pull/25)
+- **App-to-app intents shipped.** Three deliberately frozen QML symbols (`logos.request`, `logos.intentRequested`, `logos.respond`) over a host-side broker that checks the caller's own `uses` declaration and mints a dispatch id the requester never sees — so no app can forge a response or hold a handle on whoever answered. `provides` landed in the package format and intent names carried through the downloader, the lgx bundler and the module templates [logos-view-module-runtime#28](https://github.com/logos-co/logos-view-module-runtime/pull/28), [logos-basecamp#363](https://github.com/logos-co/logos-basecamp/pull/363), [logos-package#35](https://github.com/logos-co/logos-package/pull/35), [logos-package-downloader#34](https://github.com/logos-co/logos-package-downloader/pull/34), [nix-bundle-lgx#13](https://github.com/logos-co/nix-bundle-lgx/pull/13)
+- **A grant one way was a grant both ways.** `TokenManager` was one flat map with no direction tag, written from both sides of every relationship — so B could call A purely because A had called B. INBOUND and OUTBOUND are now genuinely separated without moving a single byte of the struct (its layout is a cross-package ABI), and a private token store is created empty instead of being seeded with the host's own anchor [logos-protocol#73](https://github.com/logos-co/logos-protocol/pull/73), [#71](https://github.com/logos-co/logos-protocol/pull/71), [logos-logoscore-cli#104](https://github.com/logos-co/logos-logoscore-cli/pull/104), [logos-plugin-qt#26](https://github.com/logos-co/logos-plugin-qt/pull/26)
+- **Module state stopped being polled.** liblogos turns load, unload and crash into sequenced facts and feeds them to a new `modules_state` module — retiring Basecamp's 2s `QTimer` that inferred module state from package-install events, and the install/uninstall ack handshake between Basecamp and PMUI [logos-liblogos#189](https://github.com/logos-co/logos-liblogos/pull/189), [logos-modules-state-module#1](https://github.com/logos-co/logos-modules-state-module/pull/1), [logos-basecamp#362](https://github.com/logos-co/logos-basecamp/pull/362), [logos-package-manager-ui#74](https://github.com/logos-co/logos-package-manager-ui/pull/74)
+- **A declared dependency range is now enforced, end to end.** A module declaring `^2.0.0` loaded happily against an installed 1.0.0 — `module_metadata.cpp` dropped the constraint before the registry ever saw it. The range now rides the wire, the package manager evaluates it without masking a deeper mismatch, liblogos refuses at load (fails closed on an unparseable range), and Basecamp finally shows the difference [logos-liblogos#196](https://github.com/logos-co/logos-liblogos/pull/196), [logos-package-manager#38](https://github.com/logos-co/logos-package-manager/pull/38), [logos-package-manager-module#64](https://github.com/logos-co/logos-package-manager-module/pull/64), [logos-basecamp#361](https://github.com/logos-co/logos-basecamp/pull/361)
+
+## Initiatives
+
+### Human-approved signing — the EVM wallet stops holding keys
+
+The week's largest user-visible security change: signing moved from something a caller can ask for to something a person authorises, once, for a payload they were shown.
+
+- **The hole:** once an account was unlocked, *any* module could sign — `sign_*` checked only *is-unlocked*, never who was calling, and `unlock` passed `ttl: None` while eviction only fired for `Some`, making every unlock a permanent, unattributable signing oracle. `render == sign` was vacuously true: the keystore signed bytes it had never described [logos-evm-keystore-module#6](https://github.com/logos-co/logos-evm-keystore-module/pull/6)
+- **What replaced it:** three admission tiers by caller identity — the configured approver only, any *named* module plus a receipt, and ungated account management. Tiers A and B return an identical refusal string so a caller cannot probe which one it failed [logos-evm-keystore-module#6](https://github.com/logos-co/logos-evm-keystore-module/pull/6)
+- **The approver:** `signer_ui` made to work and proven end to end; five defects found by running it rather than reading it [logos-evm-signer-ui#2](https://github.com/logos-co/logos-evm-signer-ui/pull/2)
+- **The requester:** both vault-password passthroughs deleted; signing became a two-phase request that parks the job rather than a dispatch thread; history is written when a transaction is BROADCAST, not when it is requested [logos-evm-wallet-backend-module#12](https://github.com/logos-co/logos-evm-wallet-backend-module/pull/12), [logos-evm-wallet-ui#25](https://github.com/logos-co/logos-evm-wallet-ui/pull/25)
+- **Parked, honestly:** RAILGUN dropped from the backend and its Private tab removed from the UI until it is migrated off `keystore.sign_digest` [logos-evm-wallet-backend-module#13](https://github.com/logos-co/logos-evm-wallet-backend-module/pull/13), [logos-evm-wallet-ui#27](https://github.com/logos-co/logos-evm-wallet-ui/pull/27)
+- **Also:** fees taken from `fee_module` instead of derived from `gasPrice`; leaf modules pinned to the backend's own locked inputs [logos-evm-wallet-backend-module#14](https://github.com/logos-co/logos-evm-wallet-backend-module/pull/14), [logos-evm-wallet-ui#26](https://github.com/logos-co/logos-evm-wallet-ui/pull/26)
+
+### App-to-app intents
+
+- **The frozen surface:** `request()` returns void deliberately — the requester never receives a request id, so it cannot forge a `respond()` for its own request nor hold a handle to whoever answered. That single property is what lets the router underneath be replaced without any app noticing. The bridge does *no* policy; `LogosIntent.h` carries the shared vocabulary so a host's broker and the bridge can never disagree about a legal name or a legal error [logos-view-module-runtime#28](https://github.com/logos-co/logos-view-module-runtime/pull/28)
+- **The broker,** on the host/shell split: it checks the caller's `uses` declaration, resolves a provider, mints a separate dispatch id, has the presenter load and present the provider, and routes the answer back to that requester alone. The shell is a provider like any other for dispatch — and emphatically not an app, so it must never be loaded [logos-basecamp#363](https://github.com/logos-co/logos-basecamp/pull/363)
+- **Through the packaging chain:** a `provides` field in the package format, intent names in the downloader and the lgx bundler, intents in the module templates, and docs [logos-package#35](https://github.com/logos-co/logos-package/pull/35), [logos-package-downloader#34](https://github.com/logos-co/logos-package-downloader/pull/34), [nix-bundle-lgx#13](https://github.com/logos-co/nix-bundle-lgx/pull/13), [logos-module-builder#219](https://github.com/logos-co/logos-module-builder/pull/219), [logos-modules-release-tool#7](https://github.com/logos-co/logos-modules-release-tool/pull/7), [logos-tutorial#85](https://github.com/logos-co/logos-tutorial/pull/85)
+- **First consumer:** PMUI asks for Settings → Repositories via an intent rather than reaching for the shell [logos-package-manager-ui#73](https://github.com/logos-co/logos-package-manager-ui/pull/73)
+
+### Caller identity, put to work
+
+Protocol 0.6's caller accessor landed the week before; this week it started retiring the tokens it makes unnecessary.
+
+- `capability_module` identifies the `requestModule` caller from the RPC token [logos-capability-module#26](https://github.com/logos-co/logos-capability-module/pull/26), [#27](https://github.com/logos-co/logos-capability-module/pull/27)
+- `modules_state` gates ingest on `logos::currentCaller().isHost()` — authority became structural, retiring an ingest-token nonce and the `ModuleDescriptor.env` plumbing it would have required [logos-modules-state-module#1](https://github.com/logos-co/logos-modules-state-module/pull/1)
+- `logos::CallCaller` exposed from `logos_test.h`; a Rust module announces its OWN name, not `core` [logos-test-framework#7](https://github.com/logos-co/logos-test-framework/pull/7), [logos-rust-sdk#51](https://github.com/logos-co/logos-rust-sdk/pull/51)
+
+### Token direction and consumer admission
+
+- **Direction:** inbound and outbound separated without changing `TokenManager`'s layout — splitting it into three members would have moved `m_mutex` under `QMutex::fastTryLock()`'s compare-exchange offset, and host and modules ship as separate `.lgx` that mix versions at runtime by design [logos-protocol#73](https://github.com/logos-co/logos-protocol/pull/73)
+- **Empty by default:** a private store no longer copies the host's bootstrap tokens, which had let a sandboxed view present basecamp's anchor and be answered as `HostAnchor`. Half of it was live, not latent: reading a caller needed generated glue, writing one didn't [logos-protocol#71](https://github.com/logos-co/logos-protocol/pull/71)
+- **One home for admitting a non-module:** `logos::admitConsumer` replaces the same three steps hand-rolled in two applications — the pure-QML identity bug was one of them getting the order wrong. Adopted by Basecamp, the standalone app, and the ui-host adopting its parent's credential [logos-plugin-qt#27](https://github.com/logos-co/logos-plugin-qt/pull/27), [logos-basecamp#359](https://github.com/logos-co/logos-basecamp/pull/359), [logos-standalone-app#42](https://github.com/logos-co/logos-standalone-app/pull/42), [logos-view-module-runtime#27](https://github.com/logos-co/logos-view-module-runtime/pull/27)
+- **The plumbing and its docs:** `informModuleToken` routed through the INBOUND door, `logos_module_accept_inbound_token` defined for cdylibs, the CLI daemon filing its client's token as INBOUND; two-sided load-time token injection and outbound core/capability tokens documented [logos-plugin-qt#26](https://github.com/logos-co/logos-plugin-qt/pull/26), [logos-cpp-sdk#151](https://github.com/logos-co/logos-cpp-sdk/pull/151), [logos-logoscore-cli#104](https://github.com/logos-co/logos-logoscore-cli/pull/104), [logos-liblogos#187](https://github.com/logos-co/logos-liblogos/pull/187), [logos-module-loader-qt#10](https://github.com/logos-co/logos-module-loader-qt/pull/10)
+
+### `modules_state` — lifecycle as sequenced facts
+
+- **The observer and the feed** ship together because the observer alone is inert. Two load-bearing rules: never dispatch under `loadMutex()` (a sink doing an RPC from inside the load path is the shape of the ui-host startup deadlock and a ~417s Basecamp stall already paid for), and one sequence counter [logos-liblogos#189](https://github.com/logos-co/logos-liblogos/pull/189)
+- **Bundled and auto-loaded** in liblogos, Basecamp and logosctl; `ready` kept across a snapshot [logos-liblogos#193](https://github.com/logos-co/logos-liblogos/pull/193), [#191](https://github.com/logos-co/logos-liblogos/pull/191), [logos-basecamp#362](https://github.com/logos-co/logos-basecamp/pull/362), [logos-logoscore-cli#110](https://github.com/logos-co/logos-logoscore-cli/pull/110)
+- **Consumers stopped guessing:** logosctl draws the line at LOADED rather than merely known, for both `watch` and `call`; the Basecamp↔PMUI ack handshake for install/uninstall/upgrade is gone [logos-logoscore-cli#109](https://github.com/logos-co/logos-logoscore-cli/pull/109), [logos-package-manager-ui#74](https://github.com/logos-co/logos-package-manager-ui/pull/74)
+
+### Dependency ranges, signatures and package identity
+
+- **Ranges:** evaluated by the package manager without masking a deeper mismatch, carried on the wire, enforced at load, and surfaced in Basecamp's sidebar and dialogs — where the gate's predicate had literally been `status == "not_installed"`, so absence was the only condition it could express. Hyphen ranges documented as supported [logos-package-manager#38](https://github.com/logos-co/logos-package-manager/pull/38), [logos-package-manager-module#64](https://github.com/logos-co/logos-package-manager-module/pull/64), [logos-liblogos#196](https://github.com/logos-co/logos-liblogos/pull/196), [logos-basecamp#361](https://github.com/logos-co/logos-basecamp/pull/361), [logos-package#38](https://github.com/logos-co/logos-package/pull/38)
+- **A pin was satisfiable by a signature that does not verify:** the resolver compared the pinned DID against a *claimed* `signer_did` populated before verification, so a forged `manifest.sig` naming the pinned DID bound to the pin. Fixed at the resolver and taken downstream [logos-package-downloader#33](https://github.com/logos-co/logos-package-downloader/pull/33), [logos-package-downloader-module#31](https://github.com/logos-co/logos-package-downloader-module/pull/31), [#29](https://github.com/logos-co/logos-package-downloader-module/pull/29)
+- **Signature surface:** an unknown signing key now says so instead of failing mutely; a consumer can carry a package's signature and check it against a DID of its own; an *installed* package can be checked, not just an archive [logos-package-manager#37](https://github.com/logos-co/logos-package-manager/pull/37), [logos-package#36](https://github.com/logos-co/logos-package/pull/36), [#37](https://github.com/logos-co/logos-package/pull/37)
+- **Install robustness:** read-only bits cleared on the destination and a partial install rolled back; the variant table and `main` resolution taken from logos-package rather than duplicated; a module is the directory it is installed in; multi-download concurrency enabled [logos-package-manager#40](https://github.com/logos-co/logos-package-manager/pull/40), [#41](https://github.com/logos-co/logos-package-manager/pull/41), [logos-module#24](https://github.com/logos-co/logos-module/pull/24), [logos-package-downloader#32](https://github.com/logos-co/logos-package-downloader/pull/32), [logos-package-downloader-module#28](https://github.com/logos-co/logos-package-downloader-module/pull/28)
+
+### Error channel and arity
+
+Last week's cross-SDK sweep continued into the sites it had missed.
+
+- A void method's REFUSAL is not a successful void call — both generated sites, then relocked into module-builder [logos-plugin-qt#28](https://github.com/logos-co/logos-plugin-qt/pull/28), [#29](https://github.com/logos-co/logos-plugin-qt/pull/29), [logos-module-builder#218](https://github.com/logos-co/logos-module-builder/pull/218)
+- A reply the consumer cannot read must not be reported as a provider refusal, in both the Qt and C++ consumers [logos-qt-sdk#44](https://github.com/logos-co/logos-qt-sdk/pull/44), [logos-cpp-sdk#150](https://github.com/logos-co/logos-cpp-sdk/pull/150)
+- The argument count is bounded above in both SDKs, and the Rust identity arm gated [logos-cpp-sdk#150](https://github.com/logos-co/logos-cpp-sdk/pull/150), [logos-rust-sdk#50](https://github.com/logos-co/logos-rust-sdk/pull/50), [logos-module-builder#216](https://github.com/logos-co/logos-module-builder/pull/216)
+- The signer half of `malformedConstraint` covered [logos-module#25](https://github.com/logos-co/logos-module/pull/25)
+
+### Conformance — the consumer axis
+
+- The ext table gained the axis its own comment said it lacked: `44 × 2 × 1` → `44 × 2 × 3`, via a Qt proxy fixture. It found a real defect — a record-bearing contract could not be consumed through a proxy at all, because generated record codecs were file-scope statics named after the record alone and the umbrella amalgamates every `<name>_api.cpp` into one TU [logos-test-modules#50](https://github.com/logos-co/logos-test-modules/pull/50), [logos-qt-sdk relock via logos-module-builder#215](https://github.com/logos-co/logos-module-builder/pull/215)
+- The same axis in Python, plus the two races two relocks exposed [logos-logoscore-py#22](https://github.com/logos-co/logos-logoscore-py/pull/22)
+- Table hygiene: the null-vs-failure classes expressed as cells, one shape for `echoOptional` and three retirements, the arity work closed on measurement, the isolate rule moved to the table where it belongs, and module-not-loaded answering one token again [logos-test-modules#49](https://github.com/logos-co/logos-test-modules/pull/49), [#51](https://github.com/logos-co/logos-test-modules/pull/51), [#52](https://github.com/logos-co/logos-test-modules/pull/52), [#54](https://github.com/logos-co/logos-test-modules/pull/54), [#55](https://github.com/logos-co/logos-test-modules/pull/55), [#56](https://github.com/logos-co/logos-test-modules/pull/56)
+
+### Protocol 0.8 / 0.9, and the relock train
+
+- `onEventWhenAvailable` takes the wildcard, like `onEvent`, and the deferred subscription carried into both Qt carriers [logos-protocol#74](https://github.com/logos-co/logos-protocol/pull/74), [logos-plugin-qt#30](https://github.com/logos-co/logos-plugin-qt/pull/30), [logos-qt-sdk#46](https://github.com/logos-co/logos-qt-sdk/pull/46)
+- liblogos onto protocol 0.8 and then `303ab08` across all three carriers; logosctl to 0.9 [logos-liblogos#186](https://github.com/logos-co/logos-liblogos/pull/186), [#190](https://github.com/logos-co/logos-liblogos/pull/190), [logos-logoscore-cli#105](https://github.com/logos-co/logos-logoscore-cli/pull/105)
+- Relocks across the module stack, plus one logos-package-manager resolved for the whole staged tree [logos-module-builder#217](https://github.com/logos-co/logos-module-builder/pull/217), [#221](https://github.com/logos-co/logos-module-builder/pull/221), [logos-module-loader-qt#11](https://github.com/logos-co/logos-module-loader-qt/pull/11), [logos-qt-sdk#45](https://github.com/logos-co/logos-qt-sdk/pull/45), [logos-capability-module#28](https://github.com/logos-co/logos-capability-module/pull/28), [logos-test-modules#53](https://github.com/logos-co/logos-test-modules/pull/53), [logos-package-manager-module#63](https://github.com/logos-co/logos-package-manager-module/pull/63), [#65](https://github.com/logos-co/logos-package-manager-module/pull/65), [#66](https://github.com/logos-co/logos-package-manager-module/pull/66), [logos-package-manager#39](https://github.com/logos-co/logos-package-manager/pull/39), [logos-package-downloader-module#30](https://github.com/logos-co/logos-package-downloader-module/pull/30), [logos-liblogos#188](https://github.com/logos-co/logos-liblogos/pull/188), [#194](https://github.com/logos-co/logos-liblogos/pull/194), [#195](https://github.com/logos-co/logos-liblogos/pull/195), [logos-logoscore-cli#112](https://github.com/logos-co/logos-logoscore-cli/pull/112), [#114](https://github.com/logos-co/logos-logoscore-cli/pull/114), [nix-bundle-logos-module-install#6](https://github.com/logos-co/nix-bundle-logos-module-install/pull/6)
+
+### Modules and releases
+
+- **libp2p:** the inbound accept queue restored — the cbind migration had rewritten `onIncomingStream` to only emit an event, leaving the queue with no writer, and nothing caught it because CI skips every integration test when `lib/libp2p.so` is absent. Peer id now reported, `pingPeer` added, queue depth and drops instrumented; the context pointer guarded against a concurrent destroy, and the integration tests build again [logos-libp2p-module#103](https://github.com/logos-co/logos-libp2p-module/pull/103), [#107](https://github.com/logos-co/logos-libp2p-module/pull/107), [#106](https://github.com/logos-co/logos-libp2p-module/pull/106)
+- **delivery:** migrated to the nim-ffi 0.3 C ABI, released as 0.2.1, demo cut alongside it, and bumped in the release set [logos-delivery-module#90](https://github.com/logos-co/logos-delivery-module/pull/90), [#92](https://github.com/logos-co/logos-delivery-module/pull/92), [#93](https://github.com/logos-co/logos-delivery-module/pull/93), [logos-delivery-demo#24](https://github.com/logos-co/logos-delivery-demo/pull/24), [#25](https://github.com/logos-co/logos-delivery-demo/pull/25), [logos-modules-release#51](https://github.com/logos-co/logos-modules-release/pull/51)
+- **blockchain module 0.2.3** released [logos-modules-release#49](https://github.com/logos-co/logos-modules-release/pull/49)
+- **storage:** `version()` renamed to `libstorageVersion()` (breaking) [logos-storage-module#81](https://github.com/logos-co/logos-storage-module/pull/81)
+- **execution zone:** the persistent path exposed via `LogosModuleContext` [logos-execution-zone-module#53](https://github.com/logos-blockchain/logos-execution-zone-module/pull/53)
+
+### UI — design system rollout
+
+- New designs landed across the blockchain and chat surfaces [logos-chat-ui#59](https://github.com/logos-co/logos-chat-ui/pull/59), [logos-blockchain-ui#61](https://github.com/logos-blockchain/logos-blockchain-ui/pull/61), [lez-explorer-ui#21](https://github.com/logos-blockchain/lez-explorer-ui/pull/21), [logos-execution-zone-wallet-ui#45](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/45)
+- The execution-zone wallet moved onto LogosDesignSystem components, reworked onboarding into two paths (create a wallet, or use an existing one), and turned tests on in CI [logos-execution-zone-wallet-ui#46](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/46), [#43](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/43), [#41](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/41), [#42](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/42)
+- App-manager icons fixed in Basecamp [logos-basecamp#376](https://github.com/logos-co/logos-basecamp/pull/376)
+
+### Basecamp test layer (MCP-driven UI tests)
+
+- Preparation work for MCP-driven UI tests, the first real assertion (welcome → "Install now" navigates to Applications), and a pre-seeded `test_qml_only` app so integration tests have something to boot [logos-basecamp#338](https://github.com/logos-co/logos-basecamp/pull/338), [#342](https://github.com/logos-co/logos-basecamp/pull/342), [#343](https://github.com/logos-co/logos-basecamp/pull/343)
+
+### Tooling, diagnostics and docs
+
+- **logosctl:** catalog package versions shown; `package search` gives one version per row with the rest named in `package show`; releases tagged from `VERSION` [logos-logoscore-cli#106](https://github.com/logos-co/logos-logoscore-cli/pull/106), [#111](https://github.com/logos-co/logos-logoscore-cli/pull/111), [#107](https://github.com/logos-co/logos-logoscore-cli/pull/107)
+- **standalone app:** logs to stderr by default — its own diagnostics were invisible — and loads the backend library the plugin actually declares [logos-standalone-app#43](https://github.com/logos-co/logos-standalone-app/pull/43), [#44](https://github.com/logos-co/logos-standalone-app/pull/44)
+- **doctests** unpinned from logoscore-cli, with the archived accounts module retired [logos-liblogos#192](https://github.com/logos-co/logos-liblogos/pull/192)
+- **tutorials** updated so UI modules use QML hot reloading correctly [logos-tutorial#86](https://github.com/logos-co/logos-tutorial/pull/86), [#78](https://github.com/logos-co/logos-tutorial/pull/78)
+
+
+## Appendix: all merged PRs, by repo
+
+[lez-explorer-ui](#lez-explorer-ui), [logos-basecamp](#logos-basecamp), [logos-blockchain-ui](#logos-blockchain-ui), [logos-capability-module](#logos-capability-module), [logos-chat-ui](#logos-chat-ui), [logos-cpp-sdk](#logos-cpp-sdk), [logos-delivery-demo](#logos-delivery-demo), [logos-delivery-module](#logos-delivery-module), [logos-evm-keystore-module](#logos-evm-keystore-module), [logos-evm-signer-ui](#logos-evm-signer-ui), [logos-evm-wallet-backend-module](#logos-evm-wallet-backend-module), [logos-evm-wallet-ui](#logos-evm-wallet-ui), [logos-execution-zone-module](#logos-execution-zone-module), [logos-execution-zone-wallet-ui](#logos-execution-zone-wallet-ui), [logos-liblogos](#logos-liblogos), [logos-libp2p-module](#logos-libp2p-module), [logos-logoscore-cli](#logos-logoscore-cli), [logos-logoscore-py](#logos-logoscore-py), [logos-module](#logos-module), [logos-module-builder](#logos-module-builder), [logos-module-loader-qt](#logos-module-loader-qt), [logos-modules-release](#logos-modules-release), [logos-modules-release-tool](#logos-modules-release-tool), [logos-modules-state-module](#logos-modules-state-module), [logos-package](#logos-package), [logos-package-downloader](#logos-package-downloader), [logos-package-downloader-module](#logos-package-downloader-module), [logos-package-manager](#logos-package-manager), [logos-package-manager-module](#logos-package-manager-module), [logos-package-manager-ui](#logos-package-manager-ui), [logos-plugin-qt](#logos-plugin-qt), [logos-protocol](#logos-protocol), [logos-qt-sdk](#logos-qt-sdk), [logos-rust-sdk](#logos-rust-sdk), [logos-standalone-app](#logos-standalone-app), [logos-storage-module](#logos-storage-module), [logos-test-framework](#logos-test-framework), [logos-test-modules](#logos-test-modules), [logos-tutorial](#logos-tutorial), [logos-view-module-runtime](#logos-view-module-runtime), [nix-bundle-lgx](#nix-bundle-lgx), [nix-bundle-logos-module-install](#nix-bundle-logos-module-install)
+
+### lez-explorer-ui
+
+- [feat: use new designs  (#21)](https://github.com/logos-blockchain/lez-explorer-ui/pull/21)
+
+### logos-basecamp
+
+- [Fix/app manager icons (#376)](https://github.com/logos-co/logos-basecamp/pull/376)
+- [feat(intents): app-to-app intents, on the host/shell split (#363)](https://github.com/logos-co/logos-basecamp/pull/363)
+- [feat: bundle modules_state (#362)](https://github.com/logos-co/logos-basecamp/pull/362)
+- [feat(deps): refuse a UI plugin whose dependency version does not satisfy its range (#361)](https://github.com/logos-co/logos-basecamp/pull/361)
+- [refactor(plugins): admit consumers through the shared verb (#359)](https://github.com/logos-co/logos-basecamp/pull/359)
+- [Test/pre-seed test_qml_only app for integration-test boot (#343)](https://github.com/logos-co/logos-basecamp/pull/343)
+- [Test/MCP UI welcome Install now navigates to Applications  (#342)](https://github.com/logos-co/logos-basecamp/pull/342)
+- [Test/MCP preparation UI tests (#338)](https://github.com/logos-co/logos-basecamp/pull/338)
+
+### logos-blockchain-ui
+
+- [feat: use new designs  (#61)](https://github.com/logos-blockchain/logos-blockchain-ui/pull/61)
+
+### logos-capability-module
+
+- [feat: bump flake.lock (#28)](https://github.com/logos-co/logos-capability-module/pull/28)
+- [chore(deps): relock caller-aware module builder (#27)](https://github.com/logos-co/logos-capability-module/pull/27)
+- [Identify requestModule caller from the RPC token (#26)](https://github.com/logos-co/logos-capability-module/pull/26)
+
+### logos-chat-ui
+
+- [feat: use new designs  (#59)](https://github.com/logos-co/logos-chat-ui/pull/59)
+
+### logos-cpp-sdk
+
+- [feat(cdylib): define logos_module_accept_inbound_token (#151)](https://github.com/logos-co/logos-cpp-sdk/pull/151)
+- [fix: bound the argument count above; and an lp reply it cannot read (#150)](https://github.com/logos-co/logos-cpp-sdk/pull/150)
+
+### logos-delivery-demo
+
+- [chore: release v0.2.1 (#25)](https://github.com/logos-co/logos-delivery-demo/pull/25)
+- [chore: bump delivery_module to v0.2.1 (#24)](https://github.com/logos-co/logos-delivery-demo/pull/24)
+
+### logos-delivery-module
+
+- [chore: bump logos delivery to latest master (#93)](https://github.com/logos-co/logos-delivery-module/pull/93)
+- [fix: set metadata version to 0.2.1 (#92)](https://github.com/logos-co/logos-delivery-module/pull/92)
+- [chore: bump logos-delivery and migrate to the nim-ffi 0.3 C ABI (#90)](https://github.com/logos-co/logos-delivery-module/pull/90)
+
+### logos-evm-keystore-module
+
+- [feat(keystore): human-approved signing replaces the unlocked-signer cache (#6)](https://github.com/logos-co/logos-evm-keystore-module/pull/6)
+
+### logos-evm-signer-ui
+
+- [feat(signer_ui): make it work, and prove it end-to-end (#2)](https://github.com/logos-co/logos-evm-signer-ui/pull/2)
+
+### logos-evm-wallet-backend-module
+
+- [feat: take fees from fee_module instead of deriving them from gasPrice (#14)](https://github.com/logos-co/logos-evm-wallet-backend-module/pull/14)
+- [drop railgun_module until it is migrated off keystore.sign_digest (#13)](https://github.com/logos-co/logos-evm-wallet-backend-module/pull/13)
+- [feat(wallet-backend): become a pure requester of human-approved signatures (#12)](https://github.com/logos-co/logos-evm-wallet-backend-module/pull/12)
+
+### logos-evm-wallet-ui
+
+- [drop the Private (RAILGUN) tab until railgun is migrated (#27)](https://github.com/logos-co/logos-evm-wallet-ui/pull/27)
+- [flake: pin the leaf modules to the backend's own locked inputs (#26)](https://github.com/logos-co/logos-evm-wallet-ui/pull/26)
+- [feat(wallet-ui): stop handling the vault password (#25)](https://github.com/logos-co/logos-evm-wallet-ui/pull/25)
+
+### logos-execution-zone-module
+
+- [feat: use and expose persistent path exposed by using LogosModuleContext (#53)](https://github.com/logos-blockchain/logos-execution-zone-module/pull/53)
+
+### logos-execution-zone-wallet-ui
+
+- [chore: use LogosDesignSystem components (#46)](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/46)
+- [feat: use new designs  (#45)](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/45)
+- [chore: use LogosDesignSystem components (#43)](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/43)
+- [chore: enabled tests on ci (#42)](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/42)
+- [fix: imrpove the onaboaridng flow, 2 options create wallet using wall… (#41)](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui/pull/41)
+
+### logos-liblogos
+
+- [feat: enforce a dependency's declared version range at load (#196)](https://github.com/logos-co/logos-liblogos/pull/196)
+- [chore(deps): bump logos-package-manager fb8fb6a -> d88abaa (#195)](https://github.com/logos-co/logos-liblogos/pull/195)
+- [feat: bump flake.lock (#194)](https://github.com/logos-co/logos-liblogos/pull/194)
+- [feat: bundle and auto-load modules_state (#193)](https://github.com/logos-co/logos-liblogos/pull/193)
+- [fix(doctests): unpin logoscore-cli, and retire the archived accounts … (#192)](https://github.com/logos-co/logos-liblogos/pull/192)
+- [fix(core): keep `ready` across a snapshot (#191)](https://github.com/logos-co/logos-liblogos/pull/191)
+- [chore(deps): protocol 303ab08 across all three carriers (#190)](https://github.com/logos-co/logos-liblogos/pull/190)
+- [feat(core): turn module lifecycle into sequenced facts, and feed them to modules_state (#189)](https://github.com/logos-co/logos-liblogos/pull/189)
+- [chore(deps): relock module loader stack (#188)](https://github.com/logos-co/logos-liblogos/pull/188)
+- [Document two-sided load-time token injection (#187)](https://github.com/logos-co/logos-liblogos/pull/187)
+- [chore(deps): move onto logos-protocol 0.8 and logos-plugin-qt master (#186)](https://github.com/logos-co/logos-liblogos/pull/186)
+
+### logos-libp2p-module
+
+- [fix(ctx): guard the libp2p context pointer against a concurrent destroy (#107)](https://github.com/logos-co/logos-libp2p-module/pull/107)
+- [fix(tests): find liblibp2p.so, so the integration tests build again (#106)](https://github.com/logos-co/logos-libp2p-module/pull/106)
+- [feat(bridge): restore the inbound accept queue, report the peer id, add pingPeer (#103)](https://github.com/logos-co/logos-libp2p-module/pull/103)
+
+### logos-logoscore-cli
+
+- [chore(flake): resolve one logos-package-manager for the whole staged tree (#114)](https://github.com/logos-co/logos-logoscore-cli/pull/114)
+- [chore(deps): bump logos-package-manager-module and logos-liblogos (install stages and swaps) (#112)](https://github.com/logos-co/logos-logoscore-cli/pull/112)
+- [fix(search): one version per row, and name the rest in `package show` (#111)](https://github.com/logos-co/logos-logoscore-cli/pull/111)
+- [feat: bundle modules_state, and stop claiming the doc-tests pin an exact list (#110)](https://github.com/logos-co/logos-logoscore-cli/pull/110)
+- [fix: draw the line at LOADED, not merely known — for both watch and call (#109)](https://github.com/logos-co/logos-logoscore-cli/pull/109)
+- [fix(release): tag releases from VERSION (#107)](https://github.com/logos-co/logos-logoscore-cli/pull/107)
+- [feat(logosctl): show catalog package versions (#106)](https://github.com/logos-co/logos-logoscore-cli/pull/106)
+- [chore: bump protocol to 0.9 (#105)](https://github.com/logos-co/logos-logoscore-cli/pull/105)
+- [fix(daemon): file the CLI client's token as INBOUND, not outbound (#104)](https://github.com/logos-co/logos-logoscore-cli/pull/104)
+
+### logos-logoscore-py
+
+- [conformance: the consumer axis, two relocks, and the two races they exposed (#22)](https://github.com/logos-co/logos-logoscore-py/pull/22)
+
+### logos-module
+
+- [test: cover the signer half of malformedConstraint (#25)](https://github.com/logos-co/logos-module/pull/25)
+- [feat: the module is the directory it is installed in (#24)](https://github.com/logos-co/logos-module/pull/24)
+
+### logos-module-builder
+
+- [feat: bump flake.lock (#221)](https://github.com/logos-co/logos-module-builder/pull/221)
+- [feat: add support for intents in templates and bump flake.lock (#219)](https://github.com/logos-co/logos-module-builder/pull/219)
+- [chore(deps): bump logos-plugin-qt for the second void-refusal site (#218)](https://github.com/logos-co/logos-module-builder/pull/218)
+- [chore(deps): relock protocol 0.8 module stack (#217)](https://github.com/logos-co/logos-module-builder/pull/217)
+- [chore(deps): bump the three SDKs for the arity bound and the result decode (#216)](https://github.com/logos-co/logos-module-builder/pull/216)
+- [chore(deps): bump logos-qt-sdk for the record-codec qualification (#215)](https://github.com/logos-co/logos-module-builder/pull/215)
+
+### logos-module-loader-qt
+
+- [chore(deps): relock qt sdk stack (#11)](https://github.com/logos-co/logos-module-loader-qt/pull/11)
+- [Document outbound core/capability tokens at load (#10)](https://github.com/logos-co/logos-module-loader-qt/pull/10)
+
+### logos-modules-release
+
+- [Bump delivery module to 0.2.1 and add delivery demo (#51)](https://github.com/logos-co/logos-modules-release/pull/51)
+- [chore: Bump blockchain module to 0.2.3 (#49)](https://github.com/logos-co/logos-modules-release/pull/49)
+
+### logos-modules-release-tool
+
+- [chore: update docs to mention intents (#7)](https://github.com/logos-co/logos-modules-release-tool/pull/7)
+
+### logos-modules-state-module
+
+- [feat(contract)!: gate ingest on WHO the caller is, not what it knows (#1)](https://github.com/logos-co/logos-modules-state-module/pull/1)
+
+### logos-package
+
+- [docs: hyphen ranges are supported (#38)](https://github.com/logos-co/logos-package/pull/38)
+- [feat: check an installed package, not just an archive (#37)](https://github.com/logos-co/logos-package/pull/37)
+- [feat(sig): let a consumer carry a package's signature and check it against a DID of their own (#36)](https://github.com/logos-co/logos-package/pull/36)
+- [feat: suport provides field for intents (#35)](https://github.com/logos-co/logos-package/pull/35)
+
+### logos-package-downloader
+
+- [feat: support intent names and bump flake.lock (#34)](https://github.com/logos-co/logos-package-downloader/pull/34)
+- [fix(resolver): a signer pin must not bind to a signature that did not verify (#33)](https://github.com/logos-co/logos-package-downloader/pull/33)
+- [feat concurrency multi (#32)](https://github.com/logos-co/logos-package-downloader/pull/32)
+
+### logos-package-downloader-module
+
+- [chore(deps): take the fix for a signer binding that never checked the signature (#31)](https://github.com/logos-co/logos-package-downloader-module/pull/31)
+- [feat: bump flake.lock (#30)](https://github.com/logos-co/logos-package-downloader-module/pull/30)
+- [chore(deps): take the resolver fix for the empty-signer pin (#29)](https://github.com/logos-co/logos-package-downloader-module/pull/29)
+- [chore: enable concurrency multi (#28)](https://github.com/logos-co/logos-package-downloader-module/pull/28)
+
+### logos-package-manager
+
+- [refactor: take the variant table and `main` resolution from logos-package (#41)](https://github.com/logos-co/logos-package-manager/pull/41)
+- [fix(install): clear read-only bits on the destination, and roll back a partial (#40)](https://github.com/logos-co/logos-package-manager/pull/40)
+- [feat: bump flake.lock (#39)](https://github.com/logos-co/logos-package-manager/pull/39)
+- [feat(deps): evaluate a dependency's version range, and do not mask a deeper mismatch (#38)](https://github.com/logos-co/logos-package-manager/pull/38)
+- [fix(signature): say something when an unknown key signed the package (#37)](https://github.com/logos-co/logos-package-manager/pull/37)
+
+### logos-package-manager-module
+
+- [chore(deps): bump logos-package-manager to d88abaa (install stages and swaps) (#66)](https://github.com/logos-co/logos-package-manager-module/pull/66)
+- [feat: bump flake.lock (#65)](https://github.com/logos-co/logos-package-manager-module/pull/65)
+- [feat(abi): put dependency constraints on the wire (#64)](https://github.com/logos-co/logos-package-manager-module/pull/64)
+- [chore(deps): relock caller-aware module builder (#63)](https://github.com/logos-co/logos-package-manager-module/pull/63)
+
+### logos-package-manager-ui
+
+- [feat: remove the ack process between basecamp and pmui to confirm install/uninstall/upgrades (#74)](https://github.com/logos-co/logos-package-manager-ui/pull/74)
+- [feat: request Settings → Repositories via an intent (#73)](https://github.com/logos-co/logos-package-manager-ui/pull/73)
+
+### logos-plugin-qt
+
+- [chore(deps): protocol 303ab08 — the wildcard deferred subscription (#30)](https://github.com/logos-co/logos-plugin-qt/pull/30)
+- [fix(glue): the OTHER void site discarded the refusal too (#29)](https://github.com/logos-co/logos-plugin-qt/pull/29)
+- [fix(glue): a void method's REFUSAL is not a successful void call (#28)](https://github.com/logos-co/logos-plugin-qt/pull/28)
+- [feat(consumer): logos::admitConsumer — one home for admitting a non-module (#27)](https://github.com/logos-co/logos-plugin-qt/pull/27)
+- [fix(glue): route informModuleToken through the INBOUND door (#26)](https://github.com/logos-co/logos-plugin-qt/pull/26)
+
+### logos-protocol
+
+- [fix(deferred): let onEventWhenAvailable take the wildcard, like onEvent (#74)](https://github.com/logos-co/logos-protocol/pull/74)
+- [fix(tokens): separate INBOUND from OUTBOUND, without moving a single byte (#73)](https://github.com/logos-co/logos-protocol/pull/73)
+- [feat(tokens): a private store is created EMPTY, not seeded with the host anchor (#71)](https://github.com/logos-co/logos-protocol/pull/71)
+
+### logos-qt-sdk
+
+- [chore(deps): protocol 303ab08 — the wildcard deferred subscription (#46)](https://github.com/logos-co/logos-qt-sdk/pull/46)
+- [chore(deps): relock qt host stack (#45)](https://github.com/logos-co/logos-qt-sdk/pull/45)
+- [fix(qt-consumer): a reply it cannot read must not become a provider refusal (#44)](https://github.com/logos-co/logos-qt-sdk/pull/44)
+
+### logos-rust-sdk
+
+- [fix(origin): a module announces its OWN name, not "core" (#51)](https://github.com/logos-co/logos-rust-sdk/pull/51)
+- [fix: bound the argument count above, and gate the identity arm (#50)](https://github.com/logos-co/logos-rust-sdk/pull/50)
+
+### logos-standalone-app
+
+- [fix(plugins): load the backend library the plugin declares (#44)](https://github.com/logos-co/logos-standalone-app/pull/44)
+- [fix: log to stderr by default — the app's own diagnostics were invisible (#43)](https://github.com/logos-co/logos-standalone-app/pull/43)
+- [refactor(plugins): admit consumers through the shared verb (#42)](https://github.com/logos-co/logos-standalone-app/pull/42)
+
+### logos-storage-module
+
+- [refactor(api)!: rename version() to libstorageVersion() (#81)](https://github.com/logos-co/logos-storage-module/pull/81)
+
+### logos-test-framework
+
+- [Expose logos::CallCaller from logos_test.h (#7)](https://github.com/logos-co/logos-test-framework/pull/7)
+
+### logos-test-modules
+
+- [conformance: restore isolate on module-not-loaded (#56)](https://github.com/logos-co/logos-test-modules/pull/56)
+- [conformance: module-not-loaded answers one token again (#55)](https://github.com/logos-co/logos-test-modules/pull/55)
+- [docs(conformance): the isolate rule belongs to the table, not to one case (#54)](https://github.com/logos-co/logos-test-modules/pull/54)
+- [chore(deps): relock caller-aware module builder (#53)](https://github.com/logos-co/logos-test-modules/pull/53)
+- [conformance: close the arity work — retire B-arity-overflow, on measurement (#52)](https://github.com/logos-co/logos-test-modules/pull/52)
+- [fix(ext): one contract, one shape for echoOptional — and three retirements (#51)](https://github.com/logos-co/logos-test-modules/pull/51)
+- [conformance(ext): the consumer axis, and what it found (#50)](https://github.com/logos-co/logos-test-modules/pull/50)
+- [conformance: the null-vs-failure classes, as cells (#49)](https://github.com/logos-co/logos-test-modules/pull/49)
+
+### logos-tutorial
+
+- [feat: update tutorials for ui modules ot use qml hot reloading correc… (#86)](https://github.com/logos-co/logos-tutorial/pull/86)
+- [feat: updated documentation and tests for the implemented intents mec… (#85)](https://github.com/logos-co/logos-tutorial/pull/85)
+- [feat: update tutorials for ui modules ot use qml hot reloading correctly as per latest changes (#78)](https://github.com/logos-co/logos-tutorial/pull/78)
+
+### logos-view-module-runtime
+
+- [feat(intents): add the frozen app-to-app intent surface (#28)](https://github.com/logos-co/logos-view-module-runtime/pull/28)
+- [feat(ui-host): adopt the parent's credential through the shared verb (#27)](https://github.com/logos-co/logos-view-module-runtime/pull/27)
+
+### nix-bundle-lgx
+
+- [feat: support intent names and bump logos-package (#13)](https://github.com/logos-co/nix-bundle-lgx/pull/13)
+
+### nix-bundle-logos-module-install
+
+- [feat: bump flake.lock (#6)](https://github.com/logos-co/nix-bundle-logos-module-install/pull/6)


### PR DESCRIPTION
Logoscore weekly for the window **2026-08-24 .. 2026-08-30** (UTC) — 128 merged PRs across 42 repos.

Follows the convention set by the 2026-08-24 update: hand-curated `## Highlights` and `## Initiatives` above the generator's per-repo output, which is kept verbatim as `## Appendix: all merged PRs, by repo`. Every claim cites its PR, and every PR in the appendix is cited somewhere in the narrative (checked both directions — 128/128, no orphans, nothing invented).

## The week, in short

- **Human-approved signing.** The keystore's unlocked-signer cache is gone; `unlock`/`lock`/`sign_*` were deleted from the contract rather than gated, and admission is tiered by caller identity. The wallet backend became a pure requester, the wallet UI stopped handling the vault password, and `signer_ui` was proven end-to-end.
- **App-to-app intents shipped** — a frozen three-symbol QML surface over a host-side broker, plus `provides` through the packaging chain.
- **Token direction.** `TokenManager` was one flat map with no direction tag, so a grant one way was a grant both ways. INBOUND and OUTBOUND are now separated without changing the struct layout.
- **`modules_state`** turns module lifecycle into sequenced facts, retiring Basecamp's 2s polling timer and the Basecamp↔PMUI ack handshake.
- **Dependency ranges enforced end to end**, from the wire through the package manager and liblogos to Basecamp's UI.

## Note on coverage

This week's appendix was generated with seven repos added to `scripts/generate-weekly-update.sh` that the committed version does not scan — including `logos-evm-signer-ui` and `logos-modules-state-module`, which carry two of the stories above. That script change is deliberately **not** part of this PR; it needs to land separately, otherwise the next weekly will silently under-report the same repos again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)